### PR TITLE
Harden LLMQ aggregate signature cache checks

### DIFF
--- a/src/llmq/quorums_btccheckpoints.cpp
+++ b/src/llmq/quorums_btccheckpoints.cpp
@@ -35,6 +35,17 @@ static constexpr int64_t DEFAULT_BTC_HEADER_MIN_CONFIRMATIONS{1};
 
 CBTCCheckpointsHandler* btcCheckpointsHandler{nullptr};
 
+static bool HasAggregatedBTCCheckpointStructure(const CBTCCheckpointSig& btcsig)
+{
+    const auto& llmqParams = Params().GetConsensus().llmqTypeChainLocks;
+    const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
+
+    // sigChecked is shared with share verification; only threshold-shaped objects
+    // may use it as a substitute for repeated aggregate BLS verification.
+    if (btcsig.signers.size() != (size_t)signingActiveQuorumCount) return false;
+    return std::count(btcsig.signers.begin(), btcsig.signers.end(), true) >= (signingActiveQuorumCount / 2 + 1);
+}
+
 static bool ParseHexUint256Strict(const UniValue& v, uint256& out)
 {
     if (!v.isStr()) return false;
@@ -751,8 +762,7 @@ bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpointNoCache(const CBTCChec
     const auto& llmqParams = consensus.llmqTypeChainLocks;
     const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
 
-    if (btcsig.signers.size() != (size_t)signingActiveQuorumCount) return false;
-    if (std::count(btcsig.signers.begin(), btcsig.signers.end(), true) < (signingActiveQuorumCount / 2 + 1)) return false;
+    if (!HasAggregatedBTCCheckpointStructure(btcsig)) return false;
 
     const auto quorums_scanned = llmq::quorumManager->ScanQuorums(pindexScan, signingActiveQuorumCount);
     if (quorums_scanned.size() != static_cast<size_t>(signingActiveQuorumCount)) return false;
@@ -1534,6 +1544,8 @@ bool CBTCCheckpointsHandler::GetRecentBTCCheckpointByHeight(int32_t nHeight, CBT
 
 bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpoint(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan) const
 {
+    if (!HasAggregatedBTCCheckpointStructure(btcsig)) return false;
+
     const uint256 hash = ::SerializeHash(btcsig);
     {
         LOCK(cs);

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -31,6 +31,17 @@ static const std::string CLSIG_REQUESTID_PREFIX = "clsig";
 
 CChainLocksHandler* chainLocksHandler;
 
+static bool HasAggregatedChainLockStructure(const CChainLockSig& clsig)
+{
+    const auto& llmqParams = Params().GetConsensus().llmqTypeChainLocks;
+    const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
+
+    // sigChecked is shared with share verification; only threshold-shaped objects
+    // may use it as a substitute for repeated aggregate BLS verification.
+    if (clsig.signers.size() != (size_t)signingActiveQuorumCount) return false;
+    return std::count(clsig.signers.begin(), clsig.signers.end(), true) >= (signingActiveQuorumCount / 2 + 1);
+}
+
 bool CChainLockSig::IsNull() const
 {
     return nHeight == -1 && blockHash == uint256();
@@ -330,6 +341,10 @@ bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const 
 
 bool CChainLocksHandler::VerifyAggregatedChainLock(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256 &hash)
 {
+    if (!HasAggregatedChainLockStructure(clsig)) {
+        return false;
+    }
+
     {
         LOCK(cs);
         if(sigChecked.find(hash) != sigChecked.end()) {
@@ -343,14 +358,6 @@ bool CChainLocksHandler::VerifyAggregatedChainLock(const CChainLockSig& clsig, c
     std::vector<uint256> hashes;
     std::vector<CBLSPublicKey> quorumPublicKeys;
 
-    if (clsig.signers.size() != (size_t)signingActiveQuorumCount) {
-        return false;
-    }
-
-    if (std::count(clsig.signers.begin(), clsig.signers.end(), true) < (signingActiveQuorumCount / 2 + 1)) {
-        // not enough signers
-        return false;
-    }
     const auto quorums_scanned = llmq::quorumManager->ScanQuorums(pindexScan, signingActiveQuorumCount);
     if (quorums_scanned.size() != static_cast<size_t>(signingActiveQuorumCount)) {
         return false;

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -93,6 +93,37 @@ BOOST_AUTO_TEST_CASE(chainlock_share_cache_hit_requires_signer_context)
     BOOST_CHECK(ret.second == nullptr);
 }
 
+BOOST_AUTO_TEST_CASE(chainlock_aggregate_cache_hit_requires_aggregate_structure)
+{
+    BOOST_REQUIRE(llmq::chainLocksHandler != nullptr);
+
+    const CBlockIndex* pindex_tip = WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain().Tip());
+    BOOST_REQUIRE(pindex_tip != nullptr);
+
+    const size_t signing_active_quorum_count = Params().GetConsensus().llmqTypeChainLocks.signingActiveQuorumCount;
+    BOOST_REQUIRE(signing_active_quorum_count > 1);
+
+    llmq::CChainLockSig clsig;
+    clsig.nHeight = pindex_tip->nHeight;
+    clsig.blockHash = pindex_tip->GetBlockHash();
+
+    clsig.signers.assign(signing_active_quorum_count, false);
+    uint256 hash = ::SerializeHash(clsig);
+    llmq_tests::CChainLocksHandlerTestAccess::MarkSigChecked(*llmq::chainLocksHandler, hash);
+    BOOST_CHECK(!llmq::chainLocksHandler->VerifyAggregatedChainLock(clsig, pindex_tip, hash));
+
+    clsig.signers.assign(signing_active_quorum_count, false);
+    clsig.signers.front() = true;
+    hash = ::SerializeHash(clsig);
+    llmq_tests::CChainLocksHandlerTestAccess::MarkSigChecked(*llmq::chainLocksHandler, hash);
+    BOOST_CHECK(!llmq::chainLocksHandler->VerifyAggregatedChainLock(clsig, pindex_tip, hash));
+
+    clsig.signers.assign(signing_active_quorum_count - 1, true);
+    hash = ::SerializeHash(clsig);
+    llmq_tests::CChainLocksHandlerTestAccess::MarkSigChecked(*llmq::chainLocksHandler, hash);
+    BOOST_CHECK(!llmq::chainLocksHandler->VerifyAggregatedChainLock(clsig, pindex_tip, hash));
+}
+
 BOOST_AUTO_TEST_CASE(btccheckpoint_share_cache_hit_requires_signer_context)
 {
     BOOST_REQUIRE(llmq::btcCheckpointsHandler != nullptr);
@@ -122,6 +153,37 @@ BOOST_AUTO_TEST_CASE(btccheckpoint_share_cache_hit_requires_signer_context)
     BOOST_CHECK(!ok);
     BOOST_CHECK_EQUAL(ret.first, 13);
     BOOST_CHECK(ret.second == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(btccheckpoint_aggregate_cache_hit_requires_aggregate_structure)
+{
+    BOOST_REQUIRE(llmq::btcCheckpointsHandler != nullptr);
+
+    const CBlockIndex* pindex_tip = WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain().Tip());
+    BOOST_REQUIRE(pindex_tip != nullptr);
+
+    const size_t signing_active_quorum_count = Params().GetConsensus().llmqTypeChainLocks.signingActiveQuorumCount;
+    BOOST_REQUIRE(signing_active_quorum_count > 1);
+
+    llmq::CBTCCheckpointSig btcsig;
+    btcsig.nHeight = pindex_tip->nHeight;
+    btcsig.sysHash = pindex_tip->GetBlockHash();
+
+    btcsig.signers.assign(signing_active_quorum_count, false);
+    uint256 hash = ::SerializeHash(btcsig);
+    llmq_tests::CBTCCheckpointsHandlerTestAccess::MarkSigChecked(*llmq::btcCheckpointsHandler, hash);
+    BOOST_CHECK(!llmq::btcCheckpointsHandler->VerifyAggregatedBTCCheckpoint(btcsig, pindex_tip));
+
+    btcsig.signers.assign(signing_active_quorum_count, false);
+    btcsig.signers.front() = true;
+    hash = ::SerializeHash(btcsig);
+    llmq_tests::CBTCCheckpointsHandlerTestAccess::MarkSigChecked(*llmq::btcCheckpointsHandler, hash);
+    BOOST_CHECK(!llmq::btcCheckpointsHandler->VerifyAggregatedBTCCheckpoint(btcsig, pindex_tip));
+
+    btcsig.signers.assign(signing_active_quorum_count - 1, true);
+    hash = ::SerializeHash(btcsig);
+    llmq_tests::CBTCCheckpointsHandlerTestAccess::MarkSigChecked(*llmq::btcCheckpointsHandler, hash);
+    BOOST_CHECK(!llmq::btcCheckpointsHandler->VerifyAggregatedBTCCheckpoint(btcsig, pindex_tip));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.h
+++ b/src/validation.h
@@ -105,6 +105,7 @@ extern bool fRegTest;
 extern bool fSigNet;
 extern bool fNEVMConnection;
 extern std::atomic_bool fReindexGeth;
+extern RecursiveMutex cs_btcheader;
 static constexpr uint8_t NEVM_MAGIC_BYTES[4] = {'n', 'e', 'v', 'm'};
 static constexpr uint8_t BTCCHECK_MAGIC_BYTES[4] = {'b', 't', 'c', 'c'};
 static constexpr uint8_t BTCPREV_MAGIC_BYTES[4] = {'b', 't', 'c', 'p'};

--- a/test/functional/feature_llmqchainlocks.py
+++ b/test/functional/feature_llmqchainlocks.py
@@ -229,6 +229,11 @@ class LLMQChainLocksTest(DashTestFramework):
             except JSONRPCException:
                 return False
         self.wait_until(node0_has_shallow_cl_header, timeout=60)
+        def node0_is_in_shallow_cl_submit_window():
+            active_height = self.nodes[0].getblockcount() - 5
+            active_height -= active_height % 5
+            return active_height == shallow_best["height"]
+        self.wait_until(node0_is_in_shallow_cl_submit_window, timeout=60)
         node_height = self.nodes[0].submitchainlock(
             shallow_best["blockhash"],
             shallow_best["signature"],


### PR DESCRIPTION
## Summary
- Require ChainLock and BTC checkpoint aggregate verifiers to pass cheap aggregate-shape checks before trusting `sigChecked` cache hits.
- Prevent share/recovered-sig cache entries with zero/one signer from substituting for aggregate BLS verification.
- Add regression tests covering cached zero-signer, one-signer, and wrong-size aggregate objects for both CL and BTCC.

## Test plan
- `make -C src -j8 test/test_syscoin`
- `./src/test/test_syscoin --run_test=llmq_sigshare_cache_tests`

## Notes
- Attempted focused functional coverage:
  - `feature_llmqchainlocks.py` / `rpc_verifychainlock.py` are blocked in setup by descriptor wallet mode hitting `protx_register`: `Only legacy wallets are supported by this command (-4)`.
  - `feature_btcheader_policy_auxpow.py --descriptors` skips because `python3-zmq` is unavailable.

Made with [Cursor](https://cursor.com)