### PR TITLE
Cache rejected LLMQ signature messages

### DIFF
--- a/src/llmq/quorums_btccheckpoints.cpp
+++ b/src/llmq/quorums_btccheckpoints.cpp
@@ -657,7 +657,7 @@ bool CBTCCheckpointsHandler::CheckBTCHeaderSigningPolicy(const uint256& btcHash,
 bool CBTCCheckpointsHandler::AlreadyHave(const uint256& hash) const
 {
     LOCK(cs);
-    return seenBTCCheckpointSigs.count(hash) != 0;
+    return seenBTCCheckpointSigs.count(hash) != 0 || rejectedBTCCheckpointSigs.count(hash) != 0;
 }
 
 void CBTCCheckpointsHandler::Cleanup()
@@ -678,6 +678,13 @@ void CBTCCheckpointsHandler::Cleanup()
     for (auto it = seenBTCCheckpointSigs.begin(); it != seenBTCCheckpointSigs.end(); ) {
         if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - it->second >= CLEANUP_SEEN_TIMEOUT) {
             it = seenBTCCheckpointSigs.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = rejectedBTCCheckpointSigs.begin(); it != rejectedBTCCheckpointSigs.end(); ) {
+        if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - it->second >= CLEANUP_SEEN_TIMEOUT) {
+            it = rejectedBTCCheckpointSigs.erase(it);
         } else {
             ++it;
         }
@@ -756,8 +763,12 @@ bool CBTCCheckpointsHandler::GetBTCCheckpointByHash(const uint256& hash, CBTCChe
     return false;
 }
 
-bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpointNoCache(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan) const
+bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpointNoCache(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan, bool* retSigVerifyAttempted) const
 {
+    if (retSigVerifyAttempted) {
+        *retSigVerifyAttempted = false;
+    }
+
     const auto& consensus = Params().GetConsensus();
     const auto& llmqParams = consensus.llmqTypeChainLocks;
     const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
@@ -779,6 +790,9 @@ bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpointNoCache(const CBTCChec
         const uint256 requestId = ::SerializeHash(std::make_tuple(BTCCHECK_REQUESTID_PREFIX, btcsig.nHeight, quorum->qc->quorumHash));
         const uint256 signHash = llmq::BuildSignHash(quorum->qc->quorumHash, requestId, msgHash);
         hashes.emplace_back(signHash);
+    }
+    if (retSigVerifyAttempted) {
+        *retSigVerifyAttempted = true;
     }
     return btcsig.sig.VerifyInsecureAggregated(quorumPublicKeys, hashes);
 }
@@ -877,7 +891,11 @@ not_older:
     if (signers_count == 1) {
         // share
         std::pair<int, CQuorumCPtr> ret;
-        if (!VerifyBTCCheckpointShare(btccsig, pindexScan, uint256(), ret, hash)) {
+        bool sig_verify_attempted{false};
+        if (!VerifyBTCCheckpointShare(btccsig, pindexScan, uint256(), ret, hash, &sig_verify_attempted)) {
+            if (sig_verify_attempted) {
+                MarkRejectedBTCCheckpointSig(hash);
+            }
             forget_tx_hash();
             return;
         }
@@ -926,7 +944,11 @@ not_older:
     }
 
     // aggregated
-    if (!VerifyAggregatedBTCCheckpoint(btccsig, pindexScan)) {
+    bool sig_verify_attempted{false};
+    if (!VerifyAggregatedBTCCheckpoint(btccsig, pindexScan, &sig_verify_attempted)) {
+        if (sig_verify_attempted) {
+            MarkRejectedBTCCheckpointSig(hash);
+        }
         forget_tx_hash();
         return;
     }
@@ -1119,8 +1141,12 @@ void CBTCCheckpointsHandler::TrySignBTCCheckpointTip()
     }
 }
 
-bool CBTCCheckpointsHandler::VerifyBTCCheckpointShare(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash) const
+bool CBTCCheckpointsHandler::VerifyBTCCheckpointShare(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash, bool* retSigVerifyAttempted) const
 {
+    if (retSigVerifyAttempted) {
+        *retSigVerifyAttempted = false;
+    }
+
     const auto& consensus = Params().GetConsensus();
     const auto& llmqParams = consensus.llmqTypeChainLocks;
     const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
@@ -1168,6 +1194,9 @@ bool CBTCCheckpointsHandler::VerifyBTCCheckpointShare(const CBTCCheckpointSig& b
         }
 
         const uint256 signHash = llmq::BuildSignHash(quorum->qc->quorumHash, requestId, msgHash);
+        if (retSigVerifyAttempted) {
+            *retSigVerifyAttempted = true;
+        }
         if (!btcsig.sig.VerifyInsecure(quorum->qc->quorumPublicKey, signHash)) {
             return false;
         }
@@ -1253,6 +1282,24 @@ void CBTCCheckpointsHandler::AddPendingVerifiedBTCCheckpointSig(const uint256& h
         }
         if (oldest == pendingVerifiedBTCCheckpointSigs.end()) break;
         pendingVerifiedBTCCheckpointSigs.erase(oldest);
+    }
+}
+
+void CBTCCheckpointsHandler::MarkRejectedBTCCheckpointSig(const uint256& hash)
+{
+    const int64_t now = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+    LOCK(cs);
+    rejectedBTCCheckpointSigs.emplace(hash, now);
+
+    while (rejectedBTCCheckpointSigs.size() > REJECTED_BTCCSIG_MAX) {
+        auto oldest = rejectedBTCCheckpointSigs.end();
+        for (auto it = rejectedBTCCheckpointSigs.begin(); it != rejectedBTCCheckpointSigs.end(); ++it) {
+            if (oldest == rejectedBTCCheckpointSigs.end() || it->second < oldest->second) {
+                oldest = it;
+            }
+        }
+        if (oldest == rejectedBTCCheckpointSigs.end()) break;
+        rejectedBTCCheckpointSigs.erase(oldest);
     }
 }
 
@@ -1542,8 +1589,12 @@ bool CBTCCheckpointsHandler::GetRecentBTCCheckpointByHeight(int32_t nHeight, CBT
     return true;
 }
 
-bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpoint(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan) const
+bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpoint(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan, bool* retSigVerifyAttempted) const
 {
+    if (retSigVerifyAttempted) {
+        *retSigVerifyAttempted = false;
+    }
+
     if (!HasAggregatedBTCCheckpointStructure(btcsig)) return false;
 
     const uint256 hash = ::SerializeHash(btcsig);
@@ -1553,7 +1604,7 @@ bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpoint(const CBTCCheckpointS
             return true;
         }
     }
-    const bool ok = VerifyAggregatedBTCCheckpointNoCache(btcsig, pindexScan);
+    const bool ok = VerifyAggregatedBTCCheckpointNoCache(btcsig, pindexScan, retSigVerifyAttempted);
     if (ok) {
         LOCK(cs);
         sigChecked.emplace(hash, TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));

--- a/src/llmq/quorums_btccheckpoints.h
+++ b/src/llmq/quorums_btccheckpoints.h
@@ -96,6 +96,7 @@ class CBTCCheckpointsHandler : public CRecoveredSigsListener
 {
     static constexpr int32_t RECENT_BTCCHECKPOINTS_MAX{256};
     static constexpr size_t PENDING_VERIFIED_BTCCSIG_MAX{256};
+    static constexpr size_t REJECTED_BTCCSIG_MAX{4096};
     static const int64_t PENDING_VERIFIED_BTCCSIG_TIMEOUT = 1000 * 60 * 10; // 10 minutes
     static const int64_t CLEANUP_INTERVAL = 1000 * 30;
     static const int64_t CLEANUP_SEEN_TIMEOUT = 24 * 60 * 60 * 1000;
@@ -109,6 +110,7 @@ private:
 
     // hashes of btccsig objects we've already processed/relayed
     std::map<uint256, int64_t> seenBTCCheckpointSigs GUARDED_BY(cs);
+    std::map<uint256, int64_t> rejectedBTCCheckpointSigs GUARDED_BY(cs);
     mutable std::map<uint256, int64_t> sigChecked GUARDED_BY(cs);
     int64_t lastCleanupTime GUARDED_BY(cs) {0};
 
@@ -161,14 +163,15 @@ public:
     bool GetRecentBTCCheckpointByHeight(int32_t nHeight, CBTCCheckpointSig& ret) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     // Consensus-facing verifier (BLS verify), used by specialtx and miner.
-    bool VerifyAggregatedBTCCheckpoint(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool VerifyAggregatedBTCCheckpoint(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan, bool* retSigVerifyAttempted = nullptr) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
 private:
     void AddRecentBTCCheckpoint(const CBTCCheckpointSig& btcsig) EXCLUSIVE_LOCKS_REQUIRED(cs);
     bool TryUpdateBestBTCCheckpoint(const CBlockIndex* pindexScan) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    bool VerifyBTCCheckpointShare(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    bool VerifyAggregatedBTCCheckpointNoCache(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool VerifyBTCCheckpointShare(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash, bool* retSigVerifyAttempted = nullptr) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool VerifyAggregatedBTCCheckpointNoCache(const CBTCCheckpointSig& btcsig, const CBlockIndex* pindexScan, bool* retSigVerifyAttempted = nullptr) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void Cleanup() EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void MarkRejectedBTCCheckpointSig(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void AddPendingVerifiedBTCCheckpointSig(const uint256& hash, const CBTCCheckpointSig& btcsig) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void AcceptVerifiedBTCCSig(const CBTCCheckpointSig& btccsig, const uint256& hash, const CBlockIndex* pindexScan) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     bool RunBTCHeaderCommand(const std::vector<std::string>& method_and_args, UniValue& out, std::string& err) const EXCLUSIVE_LOCKS_REQUIRED(!cs);

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -125,7 +125,7 @@ void CChainLocksHandler::Stop()
 bool CChainLocksHandler::AlreadyHave(const uint256& hash)
 {
     LOCK(cs);
-    return seenChainLocks.count(hash) != 0;
+    return seenChainLocks.count(hash) != 0 || rejectedChainLocks.count(hash) != 0;
 }
 
 bool CChainLocksHandler::GetChainLockByHash(const uint256& hash, llmq::CChainLockSig& ret)
@@ -256,8 +256,12 @@ bool CChainLocksHandler::TryUpdateBestChainLock(const CBlockIndex* pindex)
 }
 
 
-bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash)
+bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash, bool* retSigVerifyAttempted)
 {
+    if (retSigVerifyAttempted) {
+        *retSigVerifyAttempted = false;
+    }
+
     const auto& consensus = Params().GetConsensus();
     const auto& llmqParams = consensus.llmqTypeChainLocks;
     const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
@@ -317,6 +321,9 @@ bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const 
         LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- CLSIG (%s) requestId=%s, signHash=%s\n",
                 __func__, clsig.ToString(), requestId.ToString(), signHash.ToString());
 
+        if (retSigVerifyAttempted) {
+            *retSigVerifyAttempted = true;
+        }
         if (clsig.sig.VerifyInsecure(quorum->qc->quorumPublicKey, signHash)) {
             if (idIn.IsNull() && !quorumSigningManager->HasRecoveredSigForId(requestId)) {
                 // We can reconstruct the CRecoveredSig from the clsig and pass it to the signing manager, which
@@ -339,8 +346,12 @@ bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const 
     return false;
 }
 
-bool CChainLocksHandler::VerifyAggregatedChainLock(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256 &hash)
+bool CChainLocksHandler::VerifyAggregatedChainLock(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256 &hash, bool* retSigVerifyAttempted)
 {
+    if (retSigVerifyAttempted) {
+        *retSigVerifyAttempted = false;
+    }
+
     if (!HasAggregatedChainLockStructure(clsig)) {
         return false;
     }
@@ -378,6 +389,9 @@ bool CChainLocksHandler::VerifyAggregatedChainLock(const CChainLockSig& clsig, c
         LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- index %d CLSIG (%s) pindexScan=%s requestId=%s (clsig.nHeight %d, quorum->qc->quorumHash %s), signHash=%s (quorum->qc->quorumHash, requestId, clsig.blockHash)\n",
                 __func__, i, clsig.ToString(), pindexScan->GetBlockHash().ToString(), requestId.ToString(), clsig.nHeight, quorum->qc->quorumHash.ToString(), signHash.ToString());
     }
+    if (retSigVerifyAttempted) {
+        *retSigVerifyAttempted = true;
+    }
     bool result = clsig.sig.VerifyInsecureAggregated(quorumPublicKeys, hashes);
     if(result) {
         LOCK(cs);
@@ -406,6 +420,24 @@ bool CChainLocksHandler::GetRecentChainLockByHeight(int32_t nHeight, CChainLockS
     return true;
 }
 
+void CChainLocksHandler::MarkRejectedChainLock(const uint256& hash)
+{
+    const int64_t now = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+    LOCK(cs);
+    rejectedChainLocks.emplace(hash, now);
+
+    while (rejectedChainLocks.size() > REJECTED_CHAINLOCKS_MAX) {
+        auto oldest = rejectedChainLocks.end();
+        for (auto it = rejectedChainLocks.begin(); it != rejectedChainLocks.end(); ++it) {
+            if (oldest == rejectedChainLocks.end() || it->second < oldest->second) {
+                oldest = it;
+            }
+        }
+        if (oldest == rejectedChainLocks.end()) break;
+        rejectedChainLocks.erase(oldest);
+    }
+}
+
 void CChainLocksHandler::AddRecentChainLock(const CChainLockSig& clsig)
 {
     if (clsig.IsNull()) {
@@ -427,7 +459,15 @@ void CChainLocksHandler::ProcessMessage(CNode* pfrom, const std::string& strComm
         CChainLockSig clsig;
         vRecv >> clsig;
         BlockValidationState state;
-        ProcessNewChainLock(pfrom->GetId(), clsig, state, ::SerializeHash(clsig));
+        if (!ProcessNewChainLock(pfrom->GetId(), clsig, state, ::SerializeHash(clsig)) && state.IsInvalid()) {
+            const std::string reject_reason = state.GetRejectReason();
+            if (reject_reason == "clsig-invalid-share-sig" || reject_reason == "clsig-invalid-sig") {
+                PeerRef peer = peerman.GetPeerRef(pfrom->GetId());
+                if (peer) {
+                    peerman.Misbehaving(*peer, 10, reject_reason);
+                }
+            }
+        }
     }
 }
 
@@ -580,9 +620,13 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
         // A part of a multi-quorum CLSIG signed by a single quorum
         std::pair<int, CQuorumCPtr> ret;
         clsig.signers.resize(signingActiveQuorumCount, false);
-        if (!VerifyChainLockShare(clsig, pindexScan, idIn, ret, hash)) {
+        bool sig_verify_attempted{false};
+        if (!VerifyChainLockShare(clsig, pindexScan, idIn, ret, hash, &sig_verify_attempted)) {
             LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- invalid CLSIG (%s), peer=%d\n", __func__, clsig.ToString(), from);
             if (from != -1) {
+                if (sig_verify_attempted) {
+                    MarkRejectedChainLock(hash);
+                }
                 {
                     LOCK(cs_main);
                     peerman.ForgetTxHash(from, hash);
@@ -638,9 +682,13 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
     } else {
         CInv clsigInv(MSG_CLSIG, hash);
         // An aggregated CLSIG
-        if (!VerifyAggregatedChainLock(clsig, pindexScan, hash)) {
+        bool sig_verify_attempted{false};
+        if (!VerifyAggregatedChainLock(clsig, pindexScan, hash, &sig_verify_attempted)) {
             LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- invalid CLSIG (%s), peer=%d\n", __func__, clsig.ToString(), from);
             if (from != -1) {
+                if (sig_verify_attempted) {
+                    MarkRejectedChainLock(hash);
+                }
                 {
                     LOCK(cs_main);
                     peerman.ForgetTxHash(from, hash);
@@ -1065,6 +1113,13 @@ void CChainLocksHandler::Cleanup()
     for (auto it = seenChainLocks.begin(); it != seenChainLocks.end(); ) {
         if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - it->second >= CLEANUP_SEEN_TIMEOUT) {
             it = seenChainLocks.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = rejectedChainLocks.begin(); it != rejectedChainLocks.end(); ) {
+        if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - it->second >= CLEANUP_SEEN_TIMEOUT) {
+            it = rejectedChainLocks.erase(it);
         } else {
             ++it;
         }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -459,7 +459,8 @@ void CChainLocksHandler::ProcessMessage(CNode* pfrom, const std::string& strComm
         CChainLockSig clsig;
         vRecv >> clsig;
         BlockValidationState state;
-        if (!ProcessNewChainLock(pfrom->GetId(), clsig, state, ::SerializeHash(clsig)) && state.IsInvalid()) {
+        bool sig_verify_attempted{false};
+        if (!ProcessNewChainLock(pfrom->GetId(), clsig, state, ::SerializeHash(clsig), uint256(), &sig_verify_attempted) && state.IsInvalid() && sig_verify_attempted) {
             const std::string reject_reason = state.GetRejectReason();
             if (reject_reason == "clsig-invalid-share-sig" || reject_reason == "clsig-invalid-sig") {
                 PeerRef peer = peerman.GetPeerRef(pfrom->GetId());
@@ -471,8 +472,12 @@ void CChainLocksHandler::ProcessMessage(CNode* pfrom, const std::string& strComm
     }
 }
 
-bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLockSig& clsig, BlockValidationState& state, const uint256& hash, const uint256& idIn )
+bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLockSig& clsig, BlockValidationState& state, const uint256& hash, const uint256& idIn, bool* retSigVerifyAttempted)
 {
+    if (retSigVerifyAttempted) {
+        *retSigVerifyAttempted = false;
+    }
+
     assert((from == -1) ^ idIn.IsNull());
     CheckActiveState();
     PeerRef peer = peerman.GetPeerRef(from);
@@ -632,6 +637,9 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
                     peerman.ForgetTxHash(from, hash);
                 }
             }
+            if (retSigVerifyAttempted) {
+                *retSigVerifyAttempted = sig_verify_attempted;
+            }
             return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "clsig-invalid-share-sig");
         }
         CInv clsigAggInv;
@@ -693,6 +701,9 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
                     LOCK(cs_main);
                     peerman.ForgetTxHash(from, hash);
                 }
+            }
+            if (retSigVerifyAttempted) {
+                *retSigVerifyAttempted = sig_verify_attempted;
             }
             return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "clsig-invalid-sig");
         }

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -120,7 +120,7 @@ public:
     std::map<CQuorumCPtr, CChainLockSigCPtr> GetBestChainLockShares() EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    bool ProcessNewChainLock(NodeId from, CChainLockSig& clsig, BlockValidationState& state, const uint256& hash, const uint256& idIn = uint256()) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool ProcessNewChainLock(NodeId from, CChainLockSig& clsig, BlockValidationState& state, const uint256& hash, const uint256& idIn = uint256(), bool* retSigVerifyAttempted = nullptr) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void NotifyHeaderTip(const CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void UpdatedBlockTip(const CBlockIndex* pindexNew, bool fInitialDownload);
     void CheckActiveState() EXCLUSIVE_LOCKS_REQUIRED(!cs);

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -74,6 +74,7 @@ class CChainLocksHandler : public CRecoveredSigsListener
     static const int64_t CLEANUP_INTERVAL = 1000 * 30;
     static const int64_t CLEANUP_SEEN_TIMEOUT = 24 * 60 * 60 * 1000;
     static constexpr int32_t RECENT_CHAINLOCKS_MAX{256};
+    static constexpr size_t REJECTED_CHAINLOCKS_MAX{4096};
 
 
 private:
@@ -96,6 +97,7 @@ private:
 
     std::map<uint256, std::pair<int, uint256> > mapSignedRequestIds GUARDED_BY(cs);
     std::map<uint256, int64_t> seenChainLocks GUARDED_BY(cs);
+    std::map<uint256, int64_t> rejectedChainLocks GUARDED_BY(cs);
     std::map<uint256, int64_t> sigChecked GUARDED_BY(cs);
 
     int64_t lastCleanupTime GUARDED_BY(cs) {0};
@@ -127,7 +129,7 @@ public:
     bool GetCLSIGFromPeers();
     bool HasChainLock(int nHeight, const uint256& blockHash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     bool HasConflictingChainLock(int nHeight, const uint256& blockHash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    bool VerifyAggregatedChainLock(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool VerifyAggregatedChainLock(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& hash, bool* retSigVerifyAttempted = nullptr) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     bool GetRecentChainLockByHeight(int32_t nHeight, CChainLockSig& ret) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 private:
     // these require locks to be held already
@@ -137,7 +139,8 @@ private:
     void AddRecentChainLock(const CChainLockSig& clsig) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     bool TryUpdateBestChainLock(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    bool VerifyChainLockShare(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool VerifyChainLockShare(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash, bool* retSigVerifyAttempted = nullptr) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void MarkRejectedChainLock(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void Cleanup() EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     friend class llmq_tests::CChainLocksHandlerTestAccess;

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -25,6 +25,11 @@ public:
         handler.sigChecked.emplace(hash, TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
     }
 
+    static void MarkRejected(llmq::CChainLocksHandler& handler, const uint256& hash)
+    {
+        handler.MarkRejectedChainLock(hash);
+    }
+
     static bool VerifyShare(
         llmq::CChainLocksHandler& handler,
         const llmq::CChainLockSig& clsig,
@@ -44,6 +49,11 @@ public:
     {
         LOCK(handler.cs);
         handler.sigChecked.emplace(hash, TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
+    }
+
+    static void MarkRejected(llmq::CBTCCheckpointsHandler& handler, const uint256& hash)
+    {
+        handler.MarkRejectedBTCCheckpointSig(hash);
     }
 
     static bool VerifyShare(
@@ -91,6 +101,17 @@ BOOST_AUTO_TEST_CASE(chainlock_share_cache_hit_requires_signer_context)
     BOOST_CHECK(!ok);
     BOOST_CHECK_EQUAL(ret.first, 11);
     BOOST_CHECK(ret.second == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(chainlock_rejected_cache_suppresses_repeated_requests)
+{
+    BOOST_REQUIRE(llmq::chainLocksHandler != nullptr);
+
+    const uint256 hash = GetRandHash();
+    BOOST_CHECK(!llmq::chainLocksHandler->AlreadyHave(hash));
+
+    llmq_tests::CChainLocksHandlerTestAccess::MarkRejected(*llmq::chainLocksHandler, hash);
+    BOOST_CHECK(llmq::chainLocksHandler->AlreadyHave(hash));
 }
 
 BOOST_AUTO_TEST_CASE(chainlock_aggregate_cache_hit_requires_aggregate_structure)
@@ -153,6 +174,17 @@ BOOST_AUTO_TEST_CASE(btccheckpoint_share_cache_hit_requires_signer_context)
     BOOST_CHECK(!ok);
     BOOST_CHECK_EQUAL(ret.first, 13);
     BOOST_CHECK(ret.second == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(btccheckpoint_rejected_cache_suppresses_repeated_requests)
+{
+    BOOST_REQUIRE(llmq::btcCheckpointsHandler != nullptr);
+
+    const uint256 hash = GetRandHash();
+    BOOST_CHECK(!llmq::btcCheckpointsHandler->AlreadyHave(hash));
+
+    llmq_tests::CBTCCheckpointsHandlerTestAccess::MarkRejected(*llmq::btcCheckpointsHandler, hash);
+    BOOST_CHECK(llmq::btcCheckpointsHandler->AlreadyHave(hash));
 }
 
 BOOST_AUTO_TEST_CASE(btccheckpoint_aggregate_cache_hit_requires_aggregate_structure)


### PR DESCRIPTION
## Summary
- Add bounded rejected-message caches for ChainLock and BTC checkpoint sig objects that reach BLS verification and fail.
- Include rejected CL/BTCC hashes in `AlreadyHave()` so repeated invalid announcements do not trigger repeated signature verification.
- Wire invalid peer-delivered CLSIG signature failures into existing misbehavior scoring and add regression coverage for rejected-cache lookups.

## Test plan
- `make -C src -j8 llmq/libsyscoin_node_a-quorums_chainlocks.o llmq/libsyscoin_node_a-quorums_btccheckpoints.o test/test_syscoin-llmq_sigshare_cache_tests.o`
- `make -C src -j8 test/test_syscoin && ./src/test/test_syscoin --run_test=llmq_sigshare_cache_tests`

## Notes
- Rejected caches are only populated after signature verification is actually attempted and fails, avoiding negative-caching transient policy/header/height misses.
- Focused functional tests remain blocked in this environment: LLMQ/Dash tests fail in setup due descriptor-wallet `protx_register` behavior, and the BTC header policy test skips without `python3-zmq`.

Made with [Cursor](https://cursor.com)