### PR TITLE
llmq: fix early-return signer comparison in quorum commitment handling

### DIFF
--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -113,7 +113,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& strC
             auto it = minableCommitmentsByQuorum.find(qc.quorumHash);
             if (it != minableCommitmentsByQuorum.end()) {
                 auto jt = minableCommitments.find(it->second);
-                if (jt != minableCommitments.end() && jt->second.CountSigners() <= qc.CountSigners()) {
+                if (jt != minableCommitments.end() && jt->second.CountSigners() >= qc.CountSigners()) {
                         bReturn = true;
                 }
             }


### PR DESCRIPTION
### Motivation
- Fix a regression where an early-return cache check in `CQuorumBlockProcessor::ProcessMessage` could cause incoming commitments with more signers to be skipped, allowing lower-quality cached commitments to suppress better ones.

### Description
- Change the signer-count comparison in `src/llmq/quorums_blockprocessor.cpp` from `jt->second.CountSigners() <= qc.CountSigners()` to `jt->second.CountSigners() >= qc.CountSigners()` so only cached commitments that are equal or better short-circuit further processing.

### Testing
- No automated tests were run in this environment; an attempt to build/tests was blocked due to missing autotools (`aclocal`), so only the minimal source change and commit were applied and verified by diff/line inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7fc3589ec8325a1e1e3a10b75d0a7)