### PR TITLE
Initialize BufferedFile type to avoid uninitialized serialization flags

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -688,7 +688,7 @@ private:
 
 public:
     BufferedFile(CAutoFile& file, uint64_t nBufSize, uint64_t nRewindIn)
-        : m_src{file}, nReadLimit{std::numeric_limits<uint64_t>::max()}, nRewind{nRewindIn}, vchBuf(nBufSize, std::byte{0})
+        : nType{file.GetType()}, m_src{file}, nReadLimit{std::numeric_limits<uint64_t>::max()}, nRewind{nRewindIn}, vchBuf(nBufSize, std::byte{0})
     {
         if (nRewindIn >= nBufSize)
             throw std::ios_base::failure("Rewind limit must be less than buffer size");


### PR DESCRIPTION
### Motivation
- Fix undefined behavior where `BufferedFile::nType` was not initialized after the `const` removal, causing `GetType()` to return an indeterminate value that can alter deserialization paths (e.g., NEVM block payload gating) when reading block files.

### Description
- Initialize `nType` from the backing `CAutoFile` via `nType{file.GetType()}` in the `BufferedFile` constructor initializer list (change localized to `src/streams.h`).

### Testing
- Ran repository inspection and commit commands including `sed -n '620,700p' src/streams.h`, `git diff -- src/streams.h`, `git add`/`git commit`, and `nl -ba src/streams.h | sed -n '684,698p' && git rev-parse --short HEAD`, all of which completed successfully; no build or runtime tests were executed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ffea286c8325b5e10bab8aae2852)