### PR TITLE
test: avoid mutating const chain params in auxpow test

### DIFF
--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -613,22 +613,19 @@ BOOST_FIXTURE_TEST_CASE (auxpow_miner_createAndLookupBlock, TestChain100Setup)
   BOOST_CHECK_THROW (miner.lookupSavedBlock ("foobar"), UniValue);
 }
 // SYSCOIN
-BOOST_FIXTURE_TEST_CASE(auxpow_miner_regeneratesTemplateOnBTCPREVChange, TestChain100Setup)
+
+struct AuxpowCLReceiptStartZeroSetup : TestChain100Setup {
+  AuxpowCLReceiptStartZeroSetup()
+      : TestChain100Setup(ChainType::REGTEST, {"-clreceiptstartheight=0"}) {}
+};
+
+BOOST_FIXTURE_TEST_CASE(auxpow_miner_regeneratesTemplateOnBTCPREVChange, AuxpowCLReceiptStartZeroSetup)
 {
   CTxMemPool mempool{MemPoolOptionsForTest(m_node)};
   AuxpowMinerForTest miner;
   CScript scriptPubKey;
   const uint256 btc_prev_1 = uint256S(std::string(64, '1'));
   const uint256 btc_prev_2 = uint256S(std::string(64, '2'));
-
-  auto& consensus = const_cast<Consensus::Params&>(Params().GetConsensus());
-  const int old_cl_start = consensus.nCLReceiptStartBlock;
-  struct ScopedCLReceiptStartRestore {
-    Consensus::Params& params;
-    int old_value;
-    ~ScopedCLReceiptStartRestore() { params.nCLReceiptStartBlock = old_value; }
-  } restore_cl_start{consensus, old_cl_start};
-  consensus.nCLReceiptStartBlock = 0;
 
   // Move to height 101 so next template is for height 102 (sign-offset height).
   CreateAndProcessBlock({}, scriptPubKey);


### PR DESCRIPTION
### Motivation
- Avoid undefined behavior caused by `const_cast`-based mutation of regtest chain parameters in a unit test while preserving the original test intent.

### Description
- Add `AuxpowCLReceiptStartZeroSetup` (deriving from `TestChain100Setup`) that passes `"-clreceiptstartheight=0"` at construction and update `auxpow_miner_regeneratesTemplateOnBTCPREVChange` to use it, removing the `const_cast` mutation and restoration code in `src/test/auxpow_tests.cpp`.

### Testing
- `git diff --check` succeeded and the change was committed; no unit-test runs were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80b28878c8325ae5e6503411d3e50)