### PR TITLE
shutdown: avoid early-signal crash before kernel context init

### DIFF
--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -13,7 +13,7 @@
 #include <assert.h>
 #include <atomic>
 #include <system_error>
-
+// SYSCOIN
 namespace {
 std::atomic<bool> g_shutdown_requested{false};
 } // namespace

--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -11,12 +11,19 @@
 #include <util/signalinterrupt.h>
 
 #include <assert.h>
+#include <atomic>
 #include <system_error>
+
+namespace {
+std::atomic<bool> g_shutdown_requested{false};
+} // namespace
 
 void StartShutdown()
 {
+    g_shutdown_requested.store(true);
+    if (!kernel::g_context) return;
     try {
-        Assert(kernel::g_context)->interrupt();
+        kernel::g_context->interrupt();
     } catch (const std::system_error&) {
         LogPrintf("Sending shutdown token failed\n");
         assert(0);
@@ -25,18 +32,23 @@ void StartShutdown()
 
 void AbortShutdown()
 {
-    Assert(kernel::g_context)->interrupt.reset();
+    g_shutdown_requested.store(false);
+    if (!kernel::g_context) return;
+    kernel::g_context->interrupt.reset();
 }
 
 bool ShutdownRequested()
 {
-    return bool{Assert(kernel::g_context)->interrupt};
+    if (g_shutdown_requested.load()) return true;
+    if (!kernel::g_context) return false;
+    return bool{kernel::g_context->interrupt};
 }
 
 void WaitForShutdown()
 {
+    if (!kernel::g_context) return;
     try {
-        Assert(kernel::g_context)->interrupt.wait();
+        kernel::g_context->interrupt.wait();
     } catch (const std::system_error&) {
         LogPrintf("Reading shutdown token failed\n");
         assert(0);


### PR DESCRIPTION
### Motivation

- Fix a startup crash window where `StartShutdown()` dereferences `kernel::g_context` via `Assert()` while signal handlers are installed earlier, which allows an early `SIGTERM` to abort the process. 

### Description

- Add an atomic fallback flag `g_shutdown_requested` to record shutdown requests that arrive before `kernel::Context` is constructed. 
- Change `StartShutdown()` to set the fallback flag first and return safely if `kernel::g_context` is not yet initialized instead of asserting. 
- Change `AbortShutdown()` to clear the fallback flag and only touch `context->interrupt` when `kernel::g_context` exists. 
- Change `ShutdownRequested()` and `WaitForShutdown()` to consult the fallback flag and to avoid dereferencing a null `kernel::g_context`.

### Testing

- An automated attempt to run a full build (`./autogen.sh`) failed in this environment due to missing build tooling (`aclocal`), so no full-project build was completed (failure). 
- File-level inspections and command outputs (e.g., viewing `src/shutdown.cpp`) were executed to verify the intended source changes (success). 
- No upstream unit or integration test suite was run in this environment due to missing build dependencies (none executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f811daac5083258c4ac881858916c3)