### PR TITLE
fuzz: fix process_message per-target message type mapping

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -199,14 +199,29 @@ def transform_process_message_target(targets, src_dir):
 
     p2p_msg_target = "process_message"
     if (p2p_msg_target, {}) in targets:
-        lines = subprocess.run(
+        msg_type_lines = subprocess.run(
             ["git", "grep", "--function-context", "g_all_net_message_types{", src_dir / "src" / "protocol.cpp"],
             check=True,
             stdout=subprocess.PIPE,
             text=True,
         ).stdout.splitlines()
-        lines = [l.split("::", 1)[1].split(",")[0].lower() for l in lines if l.startswith("src/protocol.cpp-    NetMsgType::")]
-        assert len(lines)
+        msg_type_names = [l.split("::", 1)[1].split(",")[0] for l in msg_type_lines if l.startswith("src/protocol.cpp-    NetMsgType::")]
+        assert len(msg_type_names)
+
+        msg_value_lines = subprocess.run(
+            ["git", "grep", r"const char \*[A-Z0-9_]*=", src_dir / "src" / "protocol.cpp"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.splitlines()
+        msg_type_values = {}
+        for line in msg_value_lines:
+            _, declaration = line.split(":", 1)
+            identifier = declaration.split("*", 1)[1].split("=", 1)[0].strip()
+            value = declaration.split("\"", 1)[1].split("\"", 1)[0]
+            msg_type_values[identifier] = value
+
+        lines = [msg_type_values.get(msg_type_name, msg_type_name.lower()) for msg_type_name in msg_type_names]
         targets += [(p2p_msg_target, {"LIMIT_TO_MESSAGE_TYPE": m}) for m in lines]
     return targets
 

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -205,6 +205,7 @@ def transform_process_message_target(targets, src_dir):
             stdout=subprocess.PIPE,
             text=True,
         ).stdout.splitlines()
+        # SYSCOIN
         msg_type_names = [l.split("::", 1)[1].split(",")[0] for l in msg_type_lines if l.startswith("src/protocol.cpp-    NetMsgType::")]
         assert len(msg_type_names)
 


### PR DESCRIPTION
### Motivation
- The per-message fuzz target generator derived `LIMIT_TO_MESSAGE_TYPE` values by lowercasing `NetMsgType` identifiers from `g_all_net_message_types`, which does not match several Syscoin wire message strings and caused `initialize_process_message` to assert and abort those fuzz targets. 

### Description
- Update `transform_process_message_target` in `test/fuzz/test_runner.py` to first collect the `NetMsgType` identifiers referenced by `g_all_net_message_types` and then parse `const char *IDENTIFIER="wire_string"` declarations from `src/protocol.cpp` to build an identifier→wire-string mapping. 
- Generate `LIMIT_TO_MESSAGE_TYPE` values using the actual wire string when present, and fall back to the previous lowercase-derived identifier when no mapping exists, preserving compatibility. 
- This change prevents invalid `LIMIT_TO_MESSAGE_TYPE` values for Syscoin-specific messages (e.g., `SYNCSTATUSCOUNT` -> `ssc`) and avoids startup assertions in the fuzz target.

### Testing
- Ran `python3 -m py_compile test/fuzz/test_runner.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8132e7b1c8325bc345da30d9d77ea)