### PR TITLE
wallet: avoid out_of_range when bump fee map is incomplete

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -295,7 +295,9 @@ util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const
 
         /* Set some defaults for depth, spendable, solvable, safe, time, and from_me as these don't matter for preset inputs since no selection is being done. */
         COutput output(outpoint, txout, /*depth=*/ 0, input_bytes, /*spendable=*/ true, /*solvable=*/ true, /*safe=*/ true, /*time=*/ 0, /*from_me=*/ false, coin_selection_params.m_effective_feerate);
-        output.ApplyBumpFee(map_of_bump_fees.at(output.outpoint));
+        if (const auto it = map_of_bump_fees.find(output.outpoint); it != map_of_bump_fees.end()) {
+            output.ApplyBumpFee(it->second);
+        }
         result.Insert(output, coin_selection_params.m_subtract_fee_outputs);
     }
     return result;
@@ -457,7 +459,9 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
         for (auto& [_, outputs] : result.coins) {
             for (auto& output : outputs) {
-                output.ApplyBumpFee(map_of_bump_fees.at(output.outpoint));
+                if (const auto it = map_of_bump_fees.find(output.outpoint); it != map_of_bump_fees.end()) {
+                    output.ApplyBumpFee(it->second);
+                }
             }
         }
     }

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -295,6 +295,7 @@ util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const
 
         /* Set some defaults for depth, spendable, solvable, safe, time, and from_me as these don't matter for preset inputs since no selection is being done. */
         COutput output(outpoint, txout, /*depth=*/ 0, input_bytes, /*spendable=*/ true, /*solvable=*/ true, /*safe=*/ true, /*time=*/ 0, /*from_me=*/ false, coin_selection_params.m_effective_feerate);
+        // SYSCOIN
         if (const auto it = map_of_bump_fees.find(output.outpoint); it != map_of_bump_fees.end()) {
             output.ApplyBumpFee(it->second);
         }
@@ -459,6 +460,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
         for (auto& [_, outputs] : result.coins) {
             for (auto& output : outputs) {
+                // SYSCOIN
                 if (const auto it = map_of_bump_fees.find(output.outpoint); it != map_of_bump_fees.end()) {
                     output.ApplyBumpFee(it->second);
                 }


### PR DESCRIPTION
### Motivation
- Prevent a wallet process crash when `CalculateIndividualBumpFees()` returns an empty or partial map because unconfirmed mempool clusters hit the DoS limit, which previously led to `std::out_of_range` from `std::map::at()` during coin selection or coin listing.

### Description
- Replace unconditional `map_of_bump_fees.at(output.outpoint)` lookups with a guarded `find()` check in `FetchSelectedInputs` so bump fees are applied only when an entry exists in the map.
- Apply the same defensive `find()` lookup change in `AvailableCoins` when applying per-output bump fees.
- Keep the change minimal and backward-compatible by preserving existing bump-fee application when entries are present and silently skipping per-input bump adjustment when bump-fee data is unavailable.

### Testing
- No unit or functional test suite was executed in this environment because automated build attempts failed due to missing system dependencies (running `./autogen.sh` failed for missing `aclocal` and a direct `g++` compile failed for missing Boost headers).
- The change was validated by static inspection and a local source edit showing the intended guarded lookups in `src/wallet/spend.cpp` (no build/test run completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f817bc4fcc8325b55de71b0ea9891b)