### PR TITLE
evo: make NEVM diff emission order deterministic

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -627,8 +627,18 @@ void CDeterministicMNList::BuildDiff(const CDeterministicMNList& to, CDeterminis
         };
     }
 
-    // Now convert the deduplicated map into the diff vectors.
+    // Convert the deduplicated map into a deterministic order before filling diff vectors.
+    std::vector<std::pair<uint256, NEVMDiffEntry>> orderedNEVMDiffEntries;
+    orderedNEVMDiffEntries.reserve(nevmDiffMap.size());
     for (const auto& pair : nevmDiffMap) {
+        orderedNEVMDiffEntries.emplace_back(pair.first, pair.second);
+    }
+    std::sort(orderedNEVMDiffEntries.begin(), orderedNEVMDiffEntries.end(),
+              [](const auto& a, const auto& b) {
+                  return a.first < b.first;
+              });
+
+    for (const auto& pair : orderedNEVMDiffEntries) {
         const NEVMDiffEntry& entry = pair.second;
         switch (entry.type) {
             case NEVMDiffType::Added:


### PR DESCRIPTION
### Motivation
- `BuildDiff` accumulated NEVM address changes in an `std::unordered_map` keyed by `proTxHash` using a salted hasher, which makes iteration order randomized per process and thus non-deterministic across nodes.
- The NEVM diffs are serialized as vectors and sent over ZMQ, so nondeterministic ordering of entries can cause divergent NEVM address mappings and inconsistent NEVM validation behavior.

### Description
- Materialize the deduplicated `nevmDiffMap` into a `std::vector<std::pair<uint256, NEVMDiffEntry>>` and sort it by `proTxHash` to ensure deterministic emission order before populating serialized diff vectors.
- The change preserves existing deduplication semantics and the `Added`/`Updated`/`Removed` semantics while making output ordering deterministic.
- The fix is implemented in `src/evo/deterministicmns.cpp` within `CDeterministicMNList::BuildDiff` and only affects how `diffRetNEVMAddress` vectors are populated.

### Testing
- Source inspection and pattern checks were performed with `rg` and `sed` to locate and verify the `BuildDiff` implementation and the modified region, and these inspections succeeded.
- The patch was applied programmatically using `python3` to replace the iteration/emit block, and the modified file was inspected with `nl` to confirm the deterministic sorting code is present.
- No unit tests or CI jobs for NEVM behavior were executed in this environment, so behavioral testing against a running node or integration tests should be run in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f819330b848325a4adca43a27691a1)