### PR TITLE
validation: keep local undo during NEVM startup rollback

### DIFF
--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -235,21 +235,21 @@ bool ProcessSpecialTxsInBlock(ChainstateManager &chainman, const CBlock& block, 
     return true;
 }
 
-bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CDeterministicMNListNEVMAddressDiff& diffNEVM, bool bReverify, bool bReplay)
+bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CDeterministicMNListNEVMAddressDiff& diffNEVM, bool bUpdateSpecialTxState, bool bReplay)
 {
     try {
-        if(bReverify) {
+        if(bUpdateSpecialTxState) {
             if (!deterministicMNManager || !deterministicMNManager->UndoBlock(pindex, diffNEVM)) {
                 return false;
             }
             if (!llmq::quorumBlockProcessor->UndoBlock(block, pindex)) {
                 return false;
             }
-        }
-        // replay doesn't connect block which writes governance SB to cache again
-        if(!bReplay) {
-            if (!governance->UndoBlock(pindex)) {
-                return false;
+            // replay doesn't connect block which writes governance SB to cache again
+            if(!bReplay) {
+                if (!governance->UndoBlock(pindex)) {
+                    return false;
+                }
             }
         }
 

--- a/src/evo/specialtx.h
+++ b/src/evo/specialtx.h
@@ -25,7 +25,7 @@ class BlockManager;
 }
 bool CheckSpecialTx(node::BlockManager &blockman, const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state, CCoinsViewCache& view, bool fJustCheck, bool check_sigs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 bool ProcessSpecialTxsInBlock(ChainstateManager &chainman, const CBlock& block, const CBlockIndex* pindex, BlockValidationState& state, CDeterministicMNListNEVMAddressDiff &diff, CCoinsViewCache& view, bool fJustCheck, bool check_sigs, bool ibd) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CDeterministicMNListNEVMAddressDiff& diffNEVM, bool bReverify, bool bReplay) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CDeterministicMNListNEVMAddressDiff& diffNEVM, bool bUpdateSpecialTxState, bool bReplay) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 // SYSCOIN: helpers for extracting BTCC and BTCPREV from coinbase Syscoin-data payload.
 bool ExtractBTCCReceipt(const std::vector<unsigned char>& vchData, llmq::CBTCCheckpointSig& receipt);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2516,7 +2516,7 @@ bool ProcessNEVMData(const BlockManager& blockman, const CTransaction& tx, const
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.
  *  When FAILED is returned, view is left in an indeterminate state. */
 // SYSCOIN
-DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view, NEVMMintTxSet &setMintTxs, std::vector<uint256> &vecNEVMBlocks, std::vector<std::pair<uint256, uint32_t> > &vecTXIDPairs, bool bReverify, bool bReplay)
+DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view, NEVMMintTxSet &setMintTxs, std::vector<uint256> &vecNEVMBlocks, std::vector<std::pair<uint256, uint32_t> > &vecTXIDPairs, bool bReverify, bool bReplay, bool bUpdateSpecialTxState)
 {
     AssertLockHeld(::cs_main);
     // SYSCOIN
@@ -2534,7 +2534,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
         return DISCONNECT_FAILED;
     }
     // SYSCOIN
-    if (!UndoSpecialTxsInBlock(block, pindex, diffNEVM, bReverify, bReplay)) {
+    if (!UndoSpecialTxsInBlock(block, pindex, diffNEVM, bUpdateSpecialTxState, bReplay)) {
         error("DisconnectBlock(): UndoSpecialTxsInBlock failed!\n");
         return DISCONNECT_FAILED;
     }
@@ -3497,7 +3497,7 @@ void Chainstate::UpdateTip(const CBlockIndex* pindexNew)
   * in any case).
   */
  // SYSCOIN
-bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool, bool bReverify)
+bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool, bool bReverify, bool bUpdateSpecialTxState)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
@@ -3520,7 +3520,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     {
         CCoinsViewCache view(&CoinsTip());
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
-        if (DisconnectBlock(block, pindexDelete, view, setMintTxs, vecNEVMBlocks, vecTXIDPairs, bReverify) != DISCONNECT_OK)
+        if (DisconnectBlock(block, pindexDelete, view, setMintTxs, vecNEVMBlocks, vecTXIDPairs, bReverify, false /*bReplay*/, bUpdateSpecialTxState) != DISCONNECT_OK)
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
         bool flushed = view.Flush();
         assert(flushed);
@@ -4189,7 +4189,7 @@ void Chainstate::EnforceBlock(BlockValidationState& state, const CBlockIndex *pi
     }
 }
 // SYSCOIN
-bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex *pindex, bool bReverify)
+bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex *pindex, bool bReverify, bool bUpdateSpecialTxState)
 {
     AssertLockNotHeld(m_chainstate_mutex);
 
@@ -4251,7 +4251,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex *pinde
         // ActivateBestChain considers blocks already in m_chain
         // unconditionally valid already, so force disconnect away from it.
         DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_SIZE * 1000};
-        bool ret = DisconnectTip(state, &disconnectpool, bReverify);
+        bool ret = DisconnectTip(state, &disconnectpool, bReverify, bUpdateSpecialTxState);
         // DisconnectTip will add transactions to disconnectpool.
         // Adjust the mempool to be consistent with the new tip, adding
         // transactions back to the mempool if disconnecting was successful,
@@ -5501,7 +5501,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
         if (nCheckLevel >= 3) {
             if (curr_coins_usage <= chainstate.m_coinstip_cache_size_bytes) {
                 // SYSCOIN
-                DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins, setMintTxs, vecNEVMBlocks, vecTXIDPairs, false /*bReverify*/);
+                DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins, setMintTxs, vecNEVMBlocks, vecTXIDPairs, false /*bReverify*/, false /*bReplay*/, false /*bUpdateSpecialTxState*/);
                 if (res == DISCONNECT_FAILED) {
                     LogPrintf("Verification error: irrecoverable inconsistency in block data at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                     return VerifyDBResult::CORRUPTED_BLOCK_DB;

--- a/src/validation.h
+++ b/src/validation.h
@@ -708,7 +708,7 @@ public:
 
     // Block (dis)connection on a given view:
     // SYSCOIN
-    DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view, NEVMMintTxSet &setMintTxs, std::vector<uint256> &vecNEVMBlocks, std::vector<std::pair<uint256,uint32_t> >& vecTXIDPairs, bool bReverify = true, bool bReplay = false) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view, NEVMMintTxSet &setMintTxs, std::vector<uint256> &vecNEVMBlocks, std::vector<std::pair<uint256,uint32_t> >& vecTXIDPairs, bool bReverify = true, bool bReplay = false, bool bUpdateSpecialTxState = true) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                     CCoinsViewCache& view, bool fJustCheck = false, bool bReverify = true) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
@@ -716,7 +716,7 @@ public:
                     CCoinsViewCache& view, bool fJustCheck, NEVMMintTxSet &setMintTxs, NEVMTxRootMap &mapNEVMTxRoots, PoDAMAPMemory &mapPoDA, std::vector<std::pair<uint256, uint32_t> > &vecTXIDPairs, bool bReverify = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // SYSCOIN Apply the effects of a block disconnection on the UTXO set.
-    bool DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool, bool bReverify = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    bool DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool, bool bReverify = true, bool bUpdateSpecialTxState = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
 
     // Manual block validity manipulation:
     /** Mark a block as precious and reorganize.
@@ -728,7 +728,7 @@ public:
         LOCKS_EXCLUDED(::cs_main);
     // SYSCOIN
     /** Mark a block as invalid. */
-    bool InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex, bool bReverify = true)
+    bool InvalidateBlock(BlockValidationState& state, CBlockIndex* pindex, bool bReverify = true, bool bUpdateSpecialTxState = true)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
     // SYSCOIN


### PR DESCRIPTION
## Summary
- Split external NEVM reverify from local special transaction undo during block disconnect.
- Keep startup NEVM rollback from notifying geth while still unwinding local quorum/DMN/governance state.
- Preserve VerifyDB memory-only disconnect behavior by disabling local special-state mutation there.

## Test plan
- `git diff --check`
- IDE lints on touched files
- Attempted `make -C src -j4 validation.o evo/specialtx.o` (blocked by missing `dashbls/bls.hpp` in local environment)


Made with [Cursor](https://cursor.com)