### PR TITLE
Fix data race in CQuorum::SetSecretKeyShare

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -54,7 +54,8 @@ void CQuorum::Init(CFinalCommitmentPtr _qc, const CBlockIndex* _pQuorumBaseBlock
 
 bool CQuorum::SetSecretKeyShare(const CBLSSecretKey& secretKeyShare)
 {
-    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(GetMemberIndex(activeMasternodeInfo.proTxHash)))) {
+    const auto proTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
+    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(GetMemberIndex(proTxHash)))) {
         return false;
     }
     LOCK(cs_vvec_shShare);


### PR DESCRIPTION
### Motivation
- `CQuorum::SetSecretKeyShare` read `activeMasternodeInfo.proTxHash` without holding `activeMasternodeInfoCs`, violating the `GUARDED_BY(activeMasternodeInfoCs)` annotation and creating a data race during DKG key-share validation.

### Description
- Modified `src/llmq/quorums.cpp` to take `activeMasternodeInfoCs` and snapshot `proTxHash` via `WITH_LOCK` and then use that local `proTxHash` in `CQuorum::SetSecretKeyShare`, preserving existing validation logic while removing the unsynchronized read.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81e1e5c348325bbb143469f812fcb)