### PR TITLE
build: restore getrandom feature detection

### DIFF
--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -50,10 +50,9 @@ trap 'CI_EXEC "cat ${BASE_SCRATCH_DIR}/sanitizer-output/* 2> /dev/null"' ERR
 
 if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
   # MemorySanitizer (MSAN) does not support tracking memory initialization done by
-  # using the Linux getrandom syscall. Avoid using getrandom by undefining
-  # HAVE_SYS_GETRANDOM. See https://github.com/google/sanitizers/issues/852 for
-  # details.
-  CI_EXEC 'grep -v HAVE_SYS_GETRANDOM src/config/syscoin-config.h > src/config/syscoin-config.h.tmp && mv src/config/syscoin-config.h.tmp src/config/syscoin-config.h'
+  # using getrandom. Avoid using getrandom by undefining HAVE_GETRANDOM. See
+  # https://github.com/google/sanitizers/issues/852 for details.
+  CI_EXEC 'grep -v HAVE_GETRANDOM src/config/syscoin-config.h > src/config/syscoin-config.h.tmp && mv src/config/syscoin-config.h.tmp src/config/syscoin-config.h'
 fi
 
 if [[ "${RUN_TIDY}" == "true" ]]; then

--- a/configure.ac
+++ b/configure.ac
@@ -1206,12 +1206,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
 )
 
 dnl Check for different ways of gathering OS randomness
-AC_MSG_CHECKING([for Linux getrandom syscall])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
-  #include <sys/syscall.h>
-  #include <linux/random.h>]],
- [[ syscall(SYS_getrandom, nullptr, 32, 0); ]])],
- [ AC_MSG_RESULT([yes]); AC_DEFINE([HAVE_SYS_GETRANDOM], [1], [Define this symbol if the Linux getrandom system call is available]) ],
+AC_MSG_CHECKING([for Linux getrandom function])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+  #include <sys/random.h>]],
+ [[ getrandom(nullptr, 32, 0); ]])],
+ [ AC_MSG_RESULT([yes]); AC_DEFINE([HAVE_GETRANDOM], [1], [Define this symbol if the Linux getrandom function call is available]) ],
  [ AC_MSG_RESULT([no])]
 )
 


### PR DESCRIPTION
## Summary
- Restore the Linux configure probe to detect the libc `getrandom()` function and define `HAVE_GETRANDOM`, matching `src/random.cpp`.
- Update the MSAN CI workaround to undefine `HAVE_GETRANDOM` instead of the obsolete syscall macro.

## Test plan
- Verified the PR branch contains one focused commit and only touches `configure.ac` and `ci/test/06_script_a.sh`.
- Checked lints for the edited files in Cursor.

Made with [Cursor](https://cursor.com)