### PR TITLE
Avoid TOCTOU-triggered block read failure in FillNEVMData

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2378,13 +2378,10 @@ bool FillNEVMData(CBlock &block) {
                 CNEVMData nevmData(tx->vout[nOut].scriptPubKey);
                 if (!nevmData.IsNull()) {
                     CMutableTransaction mutable_tx(*tx);
-                    // Read blob directly to avoid TOCTOU between existence checks and reads.
-                    // Blob pruning may race with block serving; treat missing data as non-fatal.
-                    if (pnevmdatablobdb->Read(nevmData.vchVersionHash, mutable_tx.vout[nOut].vchNEVMData)) {
-                        if(!mutable_tx.vout[nOut].vchNEVMData.empty()) {
-                            // Now create the immutable CTransaction and store its Ref
-                            block.vtx[i] = MakeTransactionRef(std::move(mutable_tx));
-                        }
+                    if(pnevmdatablobdb->Read(nevmData.vchVersionHash, mutable_tx.vout[nOut].vchNEVMData) &&
+                            !mutable_tx.vout[nOut].vchNEVMData.empty()) {
+                        // Now create the immutable CTransaction and store its Ref
+                        block.vtx[i] = MakeTransactionRef(std::move(mutable_tx));
                     }
                 } else {
                     return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2377,16 +2377,13 @@ bool FillNEVMData(CBlock &block) {
                 }
                 CNEVMData nevmData(tx->vout[nOut].scriptPubKey);
                 if (!nevmData.IsNull()) {
-                    if(pnevmdatablobdb->Exists(nevmData.vchVersionHash)) {
-                        CMutableTransaction mutable_tx(*tx);
-                        // Directly modify the mutable vector
-                        if(pnevmdatablobdb->Read(nevmData.vchVersionHash, mutable_tx.vout[nOut].vchNEVMData)) {
-                            if(!mutable_tx.vout[nOut].vchNEVMData.empty()) {
-                                // Now create the immutable CTransaction and store its Ref
-                                block.vtx[i] = MakeTransactionRef(std::move(mutable_tx));
-                            }
-                        } else {
-                            return false;
+                    CMutableTransaction mutable_tx(*tx);
+                    // Read blob directly to avoid TOCTOU between existence checks and reads.
+                    // Blob pruning may race with block serving; treat missing data as non-fatal.
+                    if (pnevmdatablobdb->Read(nevmData.vchVersionHash, mutable_tx.vout[nOut].vchNEVMData)) {
+                        if(!mutable_tx.vout[nOut].vchNEVMData.empty()) {
+                            // Now create the immutable CTransaction and store its Ref
+                            block.vtx[i] = MakeTransactionRef(std::move(mutable_tx));
                         }
                     }
                 } else {


### PR DESCRIPTION
### Motivation
- A TOCTOU was introduced in `FillNEVMData` where a separate existence check on NEVM blobs could succeed but a subsequent `Read` could fail if pruning occurred, causing `FillNEVMData` to return `false` and propagate an error up `ReadBlockFromDisk` that may trigger an assert in block-serving code.
- The intent is to preserve availability when peers request blocks while pruning/flush events run, avoiding a remote timing-based crash while still populating OP_RETURN payloads when blobs are available.

### Description
- Reworked `FillNEVMData` (`src/validation.cpp`) to remove the separate `Exists`/`BlobExists` pre-check and perform a single best-effort `Read` into a `CMutableTransaction` output slot. 
- If the `Read` fails or the blob is absent, the function no longer returns `false` for this race path and instead treats missing data as non-fatal, preserving block serving.
- Preserves behavior of injecting payloads into `block.vtx` when blob data is successfully read and non-empty.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check errors and passed.
- Performed repository status checks (`git status --short`) and created the change commit successfully.
- Full build and runtime tests were not executed in this environment because autotools prerequisites are missing (`./autogen.sh` failed due to missing `aclocal`), so CI should run a full build and existing test suites to validate behavior across platforms.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f830ac90888325abae98323840a7c6)