### PR TITLE
net: cap non-transaction inventory relay per send cycle

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -6167,7 +6167,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         tx_relay->m_tx_inventory_known_filter.insert(hash);
                     }
                     // SYSCOIN Send non-tx/non-block inventory items
-                    while (!tx_relay->m_tx_inventory_to_send_other.empty()) {
+                    while (!tx_relay->m_tx_inventory_to_send_other.empty() && nRelayedTransactions < broadcast_max) {
                         // get inv's from other set to send
                         std::set<CInv>::const_iterator it = std::next(tx_relay->m_tx_inventory_to_send_other.end(), -1);
                         CInv inv = *it;
@@ -6179,6 +6179,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         }
                         // use existing limits with tx to limit other inv sends as well
                         vInv.emplace_back(inv);
+                        nRelayedTransactions++;
                         tx_relay->m_tx_inventory_known_filter.insert(inv.hash);
                         if (vInv.size() == MAX_INV_SZ) {
                             m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::INV, vInv));


### PR DESCRIPTION
### Motivation
- Prevent unbounded INV announcements from `m_tx_inventory_to_send_other` that can exhaust CPU/bandwidth and enable a network-based DoS by restoring the per-send-cycle relay cap used for transactions.

### Description
- Apply the existing per-cycle relay budget by adding `nRelayedTransactions < broadcast_max` to the non-transaction inventory loop in `PeerManagerImpl::SendMessages` and increment `nRelayedTransactions` when queuing a non-tx `CInv` so tx and non-tx announcements share the same budget.

### Testing
- No unit or integration tests were executed; an attempt to run the repository build (`./autogen.sh`) failed due to missing autotools (`aclocal`), so runtime validation could not be performed.
- Verified the change via static inspection and repository commands (`rg`, `sed`, `nl`) and committed the patch successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f830abfbf483258b74674355e39068)