### PR TITLE
guix: verify macOS SDK archive

### DIFF
--- a/contrib/containers/guix/scripts/guix-start
+++ b/contrib/containers/guix/scripts/guix-start
@@ -10,7 +10,7 @@ if [[ ! -d "${WORKSPACE_PATH}" || ! "${WORKSPACE_PATH}" = /* || ! -f "${WORKSPAC
 fi
 
 export SDK_PATH="${SDK_PATH:-${WORKSPACE_PATH}/depends/SDKs}"
-export SDK_SRCS="${SDK_PATH:-${WORKSPACE_PATH}/depends/sdk-sources}"
+export SDK_SOURCES="${SDK_SOURCES:-${WORKSPACE_PATH}/depends/sdk-sources}"
 
 ./contrib/containers/guix/scripts/setup-sdk
 

--- a/contrib/containers/guix/scripts/setup-sdk
+++ b/contrib/containers/guix/scripts/setup-sdk
@@ -12,6 +12,7 @@ SDK_PATH="${SDK_PATH:-depends/SDKs}"
 SDK_SRCS="${SDK_SOURCES:-depends/sdk-sources}"
 XCODE_VERSION="${XCODE_VERSION:-15.0}"
 XCODE_RELEASE="${XCODE_RELEASE:-15A240d}"
+XCODE_SHA256="${XCODE_SHA256:-c0c2e7bb92c1fee0c4e9f3a485e4530786732d6c6dd9e9f418c282aa6892f55d}"
 XCODE_ARCHIVE="Xcode-${XCODE_VERSION}-${XCODE_RELEASE}-extracted-SDK-with-libcxx-headers"
 XCODE_AR_PATH="${SDK_SRCS}/${XCODE_ARCHIVE}.tar.gz"
 
@@ -21,6 +22,8 @@ if [ ! -d "${SDK_PATH}/${XCODE_ARCHIVE}" ]; then
         mkdir -p "${SDK_SRCS}"
         curl --location --fail "${SDK_URL}/${XCODE_ARCHIVE}.tar.gz" -o "${XCODE_AR_PATH}"
     fi
+    echo "Verifying macOS SDK..."
+    printf "%s  %s\n" "${XCODE_SHA256}" "${XCODE_AR_PATH}" | sha256sum -c
     echo "Extracting macOS SDK..."
     mkdir -p "${SDK_PATH}"
     tar -C "${SDK_PATH}" -xf "${XCODE_AR_PATH}"


### PR DESCRIPTION
## Summary
- Verify the macOS SDK archive SHA256 before extracting it in the Guix container setup flow.
- Apply the same verification to cached SDK archives and fix the `guix-start` SDK source directory environment variable.

## Test plan
- `bash -n contrib/containers/guix/scripts/setup-sdk contrib/containers/guix/scripts/guix-start`
- Local throwaway SDK archive test: matching checksum extracts; mismatched checksum fails before extraction.
- `ReadLints` on edited Guix scripts.

Made with [Cursor](https://cursor.com)