### PR TITLE
validation: avoid invalidating blocks on PoDA sidecar mismatch

### DIFF
--- a/src/services/nevmconsensus.cpp
+++ b/src/services/nevmconsensus.cpp
@@ -43,15 +43,13 @@ void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory &mapPoDA, PoDAFlushSource
         if(!val.vchNEVMData) {
             continue;
         }
-        if(Exists(key)) {
-            if(source == PoDAFlushSource::Block) {
-                MapPoDAPayloadMeta meta;
-                if(Read(key, meta) && meta.nSize == val.nSize) {
-                    auto inserted = mapCache.try_emplace(key, val.txid, meta.nSize, val.nMedianTime);
-                    if(!inserted.second) {
-                        inserted.first->second.nMedianTime = val.nMedianTime;
-                        inserted.first->second.txid = val.txid;
-                    }
+        MapPoDAPayloadMeta meta;
+        if(Read(key, meta)) {
+            if(source == PoDAFlushSource::Block && meta.nSize == val.nSize) {
+                auto inserted = mapCache.try_emplace(key, val.txid, meta.nSize, val.nMedianTime);
+                if(!inserted.second) {
+                    inserted.first->second.nMedianTime = val.nMedianTime;
+                    inserted.first->second.txid = val.txid;
                 }
             }
             continue;
@@ -124,9 +122,9 @@ bool CNEVMDataDB::FlushErase(const NEVMDataVec &vecDataKeys) {
 }
 bool CNEVMDataDB::FlushMempoolErase(const std::vector<uint8_t>& vchVersionHash, const uint256& txid) {
     LOCK(cs_cache);
-    if(Exists(vchVersionHash)) {
-        MapPoDAPayloadMeta meta;
-        if(Read(vchVersionHash, meta) && meta.txid == txid) {
+    MapPoDAPayloadMeta meta;
+    if(Read(vchVersionHash, meta)) {
+        if(meta.txid == txid) {
             CDBBatch batch(*this);
             auto it = mapCache.find(vchVersionHash);
             if(it != mapCache.end()) {
@@ -166,10 +164,7 @@ bool CNEVMDataDB::GetBlobMetaData(const std::vector<uint8_t>& vchVersionHash, Ma
         meta = it->second;
         return true;
     } 
-    if(Exists(vchVersionHash)) {
-        return Read(vchVersionHash, meta);
-    }
-    return false;
+    return Read(vchVersionHash, meta);
 }
 const PoDAMAPMemory& CNEVMDataDB::GetCache() const {
     AssertLockHeld(cs_cache);

--- a/src/services/nevmconsensus.cpp
+++ b/src/services/nevmconsensus.cpp
@@ -128,11 +128,15 @@ bool CNEVMDataDB::FlushMempoolErase(const std::vector<uint8_t>& vchVersionHash, 
         MapPoDAPayloadMeta meta;
         if(Read(vchVersionHash, meta) && meta.txid == txid) {
             CDBBatch batch(*this);
-            batch.Erase(vchVersionHash);
             auto it = mapCache.find(vchVersionHash);
             if(it != mapCache.end()) {
+                if(it->second.txid != txid) {
+                    batch.Write(vchVersionHash, it->second);
+                    return WriteBatch(batch, true);
+                }
                 mapCache.erase(it);
             }
+            batch.Erase(vchVersionHash);
             return WriteBatch(batch, true) && pnevmdatablobdb->FlushErase({vchVersionHash});
         }
         return true;

--- a/src/services/nevmconsensus.cpp
+++ b/src/services/nevmconsensus.cpp
@@ -33,7 +33,7 @@ bool DisconnectSyscoinTransaction(const CTransaction& tx, NEVMMintTxSet &setMint
     return true;       
 }
 
-void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory &mapPoDA) {
+void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory &mapPoDA, PoDAFlushSource source) {
     LOCK(cs_cache);
     if(mapPoDA.empty()) {
         return;
@@ -44,10 +44,24 @@ void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory &mapPoDA) {
             continue;
         }
         if(Exists(key)) {
+            if(source == PoDAFlushSource::Block) {
+                MapPoDAPayloadMeta meta;
+                if(Read(key, meta)) {
+                    auto inserted = mapCache.try_emplace(key, val.txid, meta.nSize, val.nMedianTime);
+                    if(!inserted.second) {
+                        inserted.first->second.nMedianTime = val.nMedianTime;
+                        inserted.first->second.txid = val.txid;
+                    }
+                }
+            }
             continue;
         }
         auto inserted = mapCache.try_emplace(key, val.txid, val.nSize, val.nMedianTime);
         if(!inserted.second) {
+            if(source == PoDAFlushSource::Block) {
+                inserted.first->second.nMedianTime = val.nMedianTime;
+                inserted.first->second.txid = val.txid;
+            }
             continue;
         }
         if(!pnevmdatablobdb->Exists(key)) {
@@ -107,6 +121,28 @@ bool CNEVMDataDB::FlushErase(const NEVMDataVec &vecDataKeys) {
     if(vecDataKeys.size() > 0)
         LogPrint(BCLog::SYS, "Flushing, erasing %d nevm blob keys\n", vecDataKeys.size());
     return WriteBatch(batch, true) && pnevmdatablobdb->FlushErase(vecDataKeys);
+}
+bool CNEVMDataDB::FlushMempoolErase(const std::vector<uint8_t>& vchVersionHash, const uint256& txid) {
+    LOCK(cs_cache);
+    if(Exists(vchVersionHash)) {
+        MapPoDAPayloadMeta meta;
+        if(Read(vchVersionHash, meta) && meta.txid == txid) {
+            CDBBatch batch(*this);
+            batch.Erase(vchVersionHash);
+            auto it = mapCache.find(vchVersionHash);
+            if(it != mapCache.end()) {
+                mapCache.erase(it);
+            }
+            return WriteBatch(batch, true) && pnevmdatablobdb->FlushErase({vchVersionHash});
+        }
+        return true;
+    }
+    auto it = mapCache.find(vchVersionHash);
+    if(it == mapCache.end() || it->second.txid != txid) {
+        return true;
+    }
+    mapCache.erase(it);
+    return pnevmdatablobdb->FlushErase({vchVersionHash});
 }
 bool CNEVMDataBlobDB::FlushErase(const NEVMDataVec &vecDataKeys) {
     CDBBatch batch(*this);    

--- a/src/services/nevmconsensus.cpp
+++ b/src/services/nevmconsensus.cpp
@@ -46,7 +46,7 @@ void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory &mapPoDA, PoDAFlushSource
         if(Exists(key)) {
             if(source == PoDAFlushSource::Block) {
                 MapPoDAPayloadMeta meta;
-                if(Read(key, meta)) {
+                if(Read(key, meta) && meta.nSize == val.nSize) {
                     auto inserted = mapCache.try_emplace(key, val.txid, meta.nSize, val.nMedianTime);
                     if(!inserted.second) {
                         inserted.first->second.nMedianTime = val.nMedianTime;
@@ -58,7 +58,7 @@ void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory &mapPoDA, PoDAFlushSource
         }
         auto inserted = mapCache.try_emplace(key, val.txid, val.nSize, val.nMedianTime);
         if(!inserted.second) {
-            if(source == PoDAFlushSource::Block) {
+            if(source == PoDAFlushSource::Block && inserted.first->second.nSize == val.nSize) {
                 inserted.first->second.nMedianTime = val.nMedianTime;
                 inserted.first->second.txid = val.txid;
             }

--- a/src/services/nevmconsensus.cpp
+++ b/src/services/nevmconsensus.cpp
@@ -43,10 +43,12 @@ void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory &mapPoDA) {
         if(!val.vchNEVMData) {
             continue;
         }
+        if(Exists(key)) {
+            continue;
+        }
         auto inserted = mapCache.try_emplace(key, val.txid, val.nSize, val.nMedianTime);
         if(!inserted.second) {
-            inserted.first->second.nMedianTime = val.nMedianTime;
-            inserted.first->second.txid = val.txid;
+            continue;
         }
         if(!pnevmdatablobdb->Exists(key)) {
             batchblob.Write(key, val.vchNEVMData);

--- a/src/services/nevmconsensus.h
+++ b/src/services/nevmconsensus.h
@@ -20,6 +20,11 @@ class CDBBatch;
 namespace node {
     struct NodeContext;
 } // namespace node
+
+enum class PoDAFlushSource {
+    Mempool,
+    Block,
+};
     
 class CNEVMDataDB : public CDBWrapper {
 public:
@@ -29,8 +34,9 @@ private:
 public:
     using CDBWrapper::CDBWrapper;
     bool FlushErase(const NEVMDataVec &vecDataKeys) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
+    bool FlushMempoolErase(const std::vector<uint8_t>& vchVersionHash, const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     bool FlushCacheToDisk(const int64_t nMedianTime, bool fSync = true) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
-    void FlushDataToCache(const PoDAMAPMemory &mapPoDA) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
+    void FlushDataToCache(const PoDAMAPMemory &mapPoDA, PoDAFlushSource source) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     bool PruneStandalone(const int64_t nMedianTime, bool fSync = true) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     bool PruneToBatch(CDBBatch& batch,CDBBatch& batchblob,  const int64_t nMedianTime) EXCLUSIVE_LOCKS_REQUIRED(cs_cache);
     bool GetBlobMetaData(const std::vector<uint8_t>& vchVersionhash, MapPoDAPayloadMeta& meta) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);

--- a/src/test/nevm_tests.cpp
+++ b/src/test/nevm_tests.cpp
@@ -330,6 +330,20 @@ BOOST_AUTO_TEST_CASE(nevm_duplicate_blob_metadata_refresh_rules)
     BOOST_CHECK_EQUAL(meta.txid, block_txid);
     BOOST_CHECK_EQUAL(meta.nSize, 100);
     BOOST_CHECK_EQUAL(meta.nMedianTime, 4000);
+
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(version_hash, original_txid));
+    BOOST_REQUIRE(pnevmdatadb->GetBlobMetaData(version_hash, meta));
+    BOOST_CHECK_EQUAL(meta.txid, block_txid);
+    BOOST_CHECK_EQUAL(meta.nSize, 100);
+    BOOST_CHECK_EQUAL(meta.nMedianTime, 4000);
+    BOOST_CHECK(pnevmdatadb->Exists(version_hash));
+    BOOST_CHECK(pnevmdatablobdb->Exists(version_hash));
+
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(/*nMedianTime=*/4000));
+    BOOST_REQUIRE(pnevmdatadb->GetBlobMetaData(version_hash, meta));
+    BOOST_CHECK_EQUAL(meta.txid, block_txid);
+    BOOST_CHECK_EQUAL(meta.nSize, 100);
+    BOOST_CHECK_EQUAL(meta.nMedianTime, 4000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/nevm_tests.cpp
+++ b/src/test/nevm_tests.cpp
@@ -20,6 +20,31 @@
 #include <consensus/validation.h>
 #include <primitives/transaction.h>
 #include <services/assetconsensus.h>
+#include <services/nevmconsensus.h>
+
+namespace {
+CTransaction MakeNEVMDataTx(const std::vector<uint8_t>& version_hash, const std::vector<uint8_t>& data)
+{
+    CNEVMData nevmData;
+    nevmData.vchVersionHash = version_hash;
+    std::vector<unsigned char> payload;
+    nevmData.SerializeData(payload);
+
+    CMutableTransaction mtx;
+    mtx.nVersion = SYSCOIN_TX_VERSION_NEVM_DATA_SHA3;
+    mtx.vout.emplace_back(0, CScript() << OP_RETURN << payload);
+    mtx.vout.back().vchNEVMData = data;
+    return CTransaction{mtx};
+}
+
+MapPoDAPayloadMeta MakePoDAMeta(const uint256& txid, uint32_t size, int64_t median_time)
+{
+    MapPoDAPayloadMeta meta{txid, size, median_time};
+    meta.vchNEVMData = std::make_shared<const std::vector<uint8_t>>(size, uint8_t{0});
+    return meta;
+}
+} // namespace
+
 BOOST_FIXTURE_TEST_SUITE(nevm_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(seniority_test)
 {
@@ -201,4 +226,110 @@ BOOST_AUTO_TEST_CASE(nevm_blob_versionhash_formats_and_hashes)
     BOOST_CHECK(EncodeNEVMVersionHash(keccak, NEVM_DATA_LEGACY_VERSION_BYTE) == keccak);
     BOOST_CHECK(EncodeNEVMVersionHash(blake, NEVM_DATA_BLAKE2S_VERSION_BYTE) == versioned_blake);
 }
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(nevm_poda_validation_tests, RegTestingSetup)
+
+BOOST_AUTO_TEST_CASE(nevm_blob_sidecar_failures_are_auxiliary)
+{
+    pnevmdatadb = std::make_unique<CNEVMDataDB>(DBParams{
+        .path = "poda_meta",
+        .cache_bytes = static_cast<size_t>(1 << 20),
+        .memory_only = true,
+        .wipe_data = true});
+    pnevmdatablobdb = std::make_unique<CNEVMDataBlobDB>(DBParams{
+        .path = "poda_blob",
+        .cache_bytes = static_cast<size_t>(1 << 20),
+        .memory_only = true,
+        .wipe_data = true});
+
+    const std::vector<uint8_t> good_data{'g', 'o', 'o', 'd'};
+    const std::vector<uint8_t> bad_data{'b', 'a', 'd'};
+    const std::vector<uint8_t> version_hash = dev::sha3(good_data).asBytes();
+    PoDAMAPMemory mapPoDA;
+
+    BOOST_CHECK_EQUAL(
+        ProcessNEVMData(m_node.chainman->m_blockman, MakeNEVMDataTx(version_hash, bad_data), /*nMedianTime=*/100, /*nTimeNow=*/100, mapPoDA),
+        ProcessNEVMDataResult::AUX_DATA_INVALID);
+    BOOST_CHECK(mapPoDA.empty());
+
+    BOOST_CHECK_EQUAL(
+        ProcessNEVMData(m_node.chainman->m_blockman, MakeNEVMDataTx(version_hash, good_data), /*nMedianTime=*/100, /*nTimeNow=*/100, mapPoDA),
+        ProcessNEVMDataResult::VALID);
+    pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Block);
+    mapPoDA.clear();
+    BOOST_CHECK(pnevmdatadb->BlobExists(version_hash));
+
+    BOOST_CHECK_EQUAL(
+        ProcessNEVMData(m_node.chainman->m_blockman, MakeNEVMDataTx(version_hash, bad_data), /*nMedianTime=*/100, /*nTimeNow=*/100, mapPoDA),
+        ProcessNEVMDataResult::VALID);
+
+    std::vector<CTransactionRef> txs;
+    txs.emplace_back(MakeTransactionRef(CMutableTransaction{}));
+    for (int i = 0; i <= MAX_DATA_BLOBS; ++i) {
+        txs.emplace_back(MakeTransactionRef(MakeNEVMDataTx(version_hash, good_data)));
+    }
+    CBlock too_many_blobs;
+    too_many_blobs.vtx = txs;
+    mapPoDA.clear();
+    BOOST_CHECK_EQUAL(
+        ProcessNEVMData(m_node.chainman->m_blockman, too_many_blobs, /*nMedianTime=*/100, /*nTimeNow=*/100, mapPoDA),
+        ProcessNEVMDataResult::CONSENSUS_INVALID);
+}
+
+BOOST_AUTO_TEST_CASE(nevm_duplicate_blob_metadata_refresh_rules)
+{
+    pnevmdatadb = std::make_unique<CNEVMDataDB>(DBParams{
+        .path = "poda_meta_duplicates",
+        .cache_bytes = static_cast<size_t>(1 << 20),
+        .memory_only = true,
+        .wipe_data = true});
+    pnevmdatablobdb = std::make_unique<CNEVMDataBlobDB>(DBParams{
+        .path = "poda_blob_duplicates",
+        .cache_bytes = static_cast<size_t>(1 << 20),
+        .memory_only = true,
+        .wipe_data = true});
+
+    const std::vector<uint8_t> version_hash = dev::sha3(std::vector<uint8_t>{'d', 'a', 't', 'a'}).asBytes();
+    const uint256 original_txid = uint256S("01");
+    const uint256 small_txid = uint256S("02");
+    const uint256 mempool_txid = uint256S("03");
+    const uint256 block_txid = uint256S("04");
+
+    PoDAMAPMemory mapPoDA;
+    mapPoDA.emplace(version_hash, MakePoDAMeta(original_txid, /*size=*/100, /*median_time=*/1000));
+    pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(/*nMedianTime=*/1000));
+
+    MapPoDAPayloadMeta meta;
+    BOOST_REQUIRE(pnevmdatadb->GetBlobMetaData(version_hash, meta));
+    BOOST_CHECK_EQUAL(meta.txid, original_txid);
+    BOOST_CHECK_EQUAL(meta.nSize, 100);
+    BOOST_CHECK_EQUAL(meta.nMedianTime, 1000);
+
+    mapPoDA.clear();
+    mapPoDA.emplace(version_hash, MakePoDAMeta(small_txid, /*size=*/10, /*median_time=*/2000));
+    pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->GetBlobMetaData(version_hash, meta));
+    BOOST_CHECK_EQUAL(meta.txid, original_txid);
+    BOOST_CHECK_EQUAL(meta.nSize, 100);
+    BOOST_CHECK_EQUAL(meta.nMedianTime, 1000);
+
+    mapPoDA.clear();
+    mapPoDA.emplace(version_hash, MakePoDAMeta(mempool_txid, /*size=*/100, /*median_time=*/3000));
+    pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->GetBlobMetaData(version_hash, meta));
+    BOOST_CHECK_EQUAL(meta.txid, original_txid);
+    BOOST_CHECK_EQUAL(meta.nSize, 100);
+    BOOST_CHECK_EQUAL(meta.nMedianTime, 1000);
+
+    mapPoDA.clear();
+    mapPoDA.emplace(version_hash, MakePoDAMeta(block_txid, /*size=*/100, /*median_time=*/4000));
+    pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->GetBlobMetaData(version_hash, meta));
+    BOOST_CHECK_EQUAL(meta.txid, block_txid);
+    BOOST_CHECK_EQUAL(meta.nSize, 100);
+    BOOST_CHECK_EQUAL(meta.nMedianTime, 4000);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -29,7 +29,7 @@
 #include <evo/specialtx.h>
 #include <evo/providertx.h>
 #include <evo/deterministicmns.h>   
-extern bool EraseNEVMData(const NEVMDataVec&);
+extern bool EraseMempoolNEVMData(const std::vector<uint8_t>&, const uint256&);
 extern NEVMMintTxSet setMintTxsMempool;
 extern std::unordered_map<COutPoint, std::pair<CTransactionRef, CTransactionRef>, SaltedOutpointHasher> mapAssetAllocationConflicts;
 
@@ -644,11 +644,11 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         if(!mintSyscoin.IsNull())
             setMintTxsMempool.erase(mintSyscoin.nTxHash);
     }
-    // completely remove data if we are expiring due to timeout or trimming mempool, any other and it may be block related where we keep around until chainlock eventually prune them
+    // Remove only mempool-owned PoDA data on expiry/trim; confirmed and duplicate blobs are chain-owned.
     else if(it->GetTx().IsNEVMData() && (reason == MemPoolRemovalReason::EXPIRY || reason == MemPoolRemovalReason::SIZELIMIT)) {
         CNEVMData nevmData(it->GetTx());
         if(!nevmData.IsNull()){
-            EraseNEVMData({nevmData.vchVersionHash});
+            EraseMempoolNEVMData(nevmData.vchVersionHash, tx_hash);
         }
     }
     cachedInnerUsage -= memusage::DynamicUsage(it->GetMemPoolParentsConst()) + memusage::DynamicUsage(it->GetMemPoolChildrenConst());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1259,7 +1259,7 @@ bool MemPoolAccept::Finalize(const ATMPArgs& args, Workspace& ws)
 
     // SYSCOIN
     if(pnevmdatadb)
-        pnevmdatadb->FlushDataToCache(ws.mapPoDA);
+        pnevmdatadb->FlushDataToCache(ws.mapPoDA, PoDAFlushSource::Mempool);
     // trim mempool and check if tx was trimmed
     // If we are validating a package, don't trim here because we could evict a previous transaction
     // in the package. LimitMempoolSize() should be called at the very end to make sure the mempool
@@ -2402,6 +2402,12 @@ bool FillNEVMData(CBlock &block) {
 bool EraseNEVMData(const NEVMDataVec &NEVMDataVecOut) {
     if(!NEVMDataVecOut.empty()) {
         return pnevmdatadb->FlushErase(NEVMDataVecOut);
+    }
+    return true;
+}
+bool EraseMempoolNEVMData(const std::vector<uint8_t>& vchVersionHash, const uint256& txid) {
+    if(!vchVersionHash.empty()) {
+        return pnevmdatadb->FlushMempoolErase(vchVersionHash, txid);
     }
     return true;
 }
@@ -3674,7 +3680,7 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
     }
     // SYSCOIN
     if(pnevmdatadb)
-        pnevmdatadb->FlushDataToCache(mapPoDA);
+        pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Block);
     if(pnevmtxmintdb)
         pnevmtxmintdb->FlushDataToCache(setMintTxs);
     if(pblockindexdb)
@@ -5244,7 +5250,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         return error("%s: %s", __func__, state.ToString());
     }
     if(pnevmdatadb)
-        pnevmdatadb->FlushDataToCache(mapPoDA);
+        pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Block);
 
     // Header is valid/has work, merkle tree and segwit merkle tree are good...RELAY NOW
     // (but if it does not build on our best tip, let the SendMessages loop relay it)
@@ -5692,7 +5698,7 @@ bool Chainstate::ReplayBlocks()
     cache.Flush();
     // SYSCOIN
     if(pnevmdatadb) {
-        pnevmdatadb->FlushDataToCache(mapPoDAConnect);
+        pnevmdatadb->FlushDataToCache(mapPoDAConnect, PoDAFlushSource::Block);
     }
     if(pnevmtxmintdb) {
         pnevmtxmintdb->FlushDataToCache(setMintTxsConnect);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2399,12 +2399,6 @@ bool FillNEVMData(CBlock &block) {
     }
     return true;
 }
-bool EraseNEVMData(const NEVMDataVec &NEVMDataVecOut) {
-    if(!NEVMDataVecOut.empty()) {
-        return pnevmdatadb->FlushErase(NEVMDataVecOut);
-    }
-    return true;
-}
 bool EraseMempoolNEVMData(const std::vector<uint8_t>& vchVersionHash, const uint256& txid) {
     if(!vchVersionHash.empty()) {
         return pnevmdatadb->FlushMempoolErase(vchVersionHash, txid);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -926,7 +926,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }      
     
     // SYSCOIN
-    if(!ProcessNEVMData(m_active_chainstate.m_blockman, tx, m_active_chainstate.m_chain.Tip()->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(m_active_chainstate.m_chainman.m_options.adjusted_time_callback()), ws.mapPoDA)) {
+    if(ProcessNEVMData(m_active_chainstate.m_blockman, tx, m_active_chainstate.m_chain.Tip()->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(m_active_chainstate.m_chainman.m_options.adjusted_time_callback()), ws.mapPoDA) != ProcessNEVMDataResult::VALID) {
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-poda-invalid");
     }
      if (m_pool.m_require_standard && !AreInputsStandard(tx, m_view)) {
@@ -2432,7 +2432,7 @@ public:
     }
 };
 static CCheckQueue<CBlobCheck> blobcheckqueue(MAX_DATA_BLOBS);
-bool ProcessNEVMDataHelper(const BlockManager& blockman, const std::vector<CNEVMData> &vecNevmDataPayload, const int64_t &nMedianTime, const int64_t &nTimeNow, PoDAMAPMemory &mapPoDA) {
+ProcessNEVMDataResult ProcessNEVMDataHelper(const BlockManager& blockman, const std::vector<CNEVMData> &vecNevmDataPayload, const int64_t &nMedianTime, const int64_t &nTimeNow, PoDAMAPMemory &mapPoDA) {
     int64_t nMedianTimeCL = 0;
     if(llmq::chainLocksHandler) {
         const CBlockIndex* CLIndex = llmq::chainLocksHandler->GetBestChainLockIndex();
@@ -2449,10 +2449,10 @@ bool ProcessNEVMDataHelper(const BlockManager& blockman, const std::vector<CNEVM
         const bool enforceHaveData = nMedianTime >= (nTimeNow - NEVM_DATA_ENFORCE_TIME_HAVE_DATA);
         if(enforceHaveData && (!nevmDataPayload.vchNEVMData || nevmDataPayload.vchNEVMData->empty())) {
             LogPrint(BCLog::SYS, "ProcessNEVMDataHelper: Enforcing data but NEVM Data is empty nMedianTime %ld nTimeNow %ld NEVM_DATA_ENFORCE_TIME_HAVE_DATA %d\n", nMedianTime, nTimeNow, NEVM_DATA_ENFORCE_TIME_HAVE_DATA);
-            return false;
+            return ProcessNEVMDataResult::AUX_DATA_INVALID;
         } else if(enforceNotHaveData && nevmDataPayload.vchNEVMData && !nevmDataPayload.vchNEVMData->empty()) {
             LogPrint(BCLog::SYS, "ProcessNEVMDataHelper: Enforcing no data but NEVM Data is not empty nMedianTime %ld nTimeNow %ld NEVM_DATA_ENFORCE_TIME_NOT_HAVE_DATA %d\n", nMedianTime, nTimeNow, NEVM_DATA_ENFORCE_TIME_NOT_HAVE_DATA);
-            return false;
+            return ProcessNEVMDataResult::AUX_DATA_INVALID;
         }
         if(nevmDataPayload.vchNEVMData && !nevmDataPayload.vchNEVMData->empty() && !pnevmdatadb->BlobExists(nevmDataPayload.vchVersionHash)){
             vChecks.emplace_back(CBlobCheck(&nevmDataPayload));
@@ -2466,7 +2466,7 @@ bool ProcessNEVMDataHelper(const BlockManager& blockman, const std::vector<CNEVM
         control.Add(std::move(vChecks));
         if (!control.Wait()){
             LogPrint(BCLog::SYS, "ProcessNEVMDataHelper: Invalid blob(s)\n");
-            return false;
+            return ProcessNEVMDataResult::AUX_DATA_INVALID;
         }
         const auto time_2{SteadyClock::now()};
         LogPrint(BCLog::BENCHMARK, "ProcessNEVMDataHelper: verified %d blobs in %.2fms (%.2fms/blob)\n", nSizeChecks, Ticks<MillisecondsDouble>(time_2 - time_1), Ticks<MillisecondsDouble>(time_2 - time_1) / nSizeChecks);
@@ -2474,10 +2474,10 @@ bool ProcessNEVMDataHelper(const BlockManager& blockman, const std::vector<CNEVM
     for (const auto &nevmDataPayload : vecNevmDataPayload) {
         mapPoDA.try_emplace(nevmDataPayload.vchVersionHash, MapPoDAPayloadMeta(nevmDataPayload, nMedianTime));
     }
-    return true;
+    return ProcessNEVMDataResult::VALID;
 }
 // when we receive blocks/txs from peers we need to strip the OPRETURN NEVM DA payload and store separately
-bool ProcessNEVMData(const BlockManager& blockman, const CBlock &block, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA) {
+ProcessNEVMDataResult ProcessNEVMData(const BlockManager& blockman, const CBlock &block, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA) {
     std::vector<CNEVMData> vecNevmDataPayload;
     int nCountBlobs = 0;
     for (auto &tx : block.vtx) {
@@ -2485,33 +2485,30 @@ bool ProcessNEVMData(const BlockManager& blockman, const CBlock &block, const in
             nCountBlobs++;
             if(nCountBlobs > MAX_DATA_BLOBS) {
                 LogPrintf("ProcessNEVMData nCountBlobs > MAX_DATA_BLOBS, nCountBlobs: %d\n", nCountBlobs);
-                return false;
+                return ProcessNEVMDataResult::CONSENSUS_INVALID;
             }
             const CNEVMData nevmDataPayload(*tx);
             if(nevmDataPayload.IsNull()) {
-                return false;
+                return ProcessNEVMDataResult::CONSENSUS_INVALID;
             }
             vecNevmDataPayload.emplace_back(nevmDataPayload);
         }
     }
-    if(!vecNevmDataPayload.empty() && !ProcessNEVMDataHelper(blockman, vecNevmDataPayload, nMedianTime, nTimeNow, mapPoDA)) {
-        return false;
+    if(!vecNevmDataPayload.empty()) {
+        return ProcessNEVMDataHelper(blockman, vecNevmDataPayload, nMedianTime, nTimeNow, mapPoDA);
     }
-    return true;
+    return ProcessNEVMDataResult::VALID;
 }
-bool ProcessNEVMData(const BlockManager& blockman, const CTransaction& tx, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA) {
+ProcessNEVMDataResult ProcessNEVMData(const BlockManager& blockman, const CTransaction& tx, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA) {
     if(!tx.IsNEVMData()) {
-        return true;
+        return ProcessNEVMDataResult::VALID;
     }
     const CNEVMData nevmDataPayload(tx);
     if(nevmDataPayload.IsNull()) {
-        return false;
+        return ProcessNEVMDataResult::CONSENSUS_INVALID;
     }
     std::vector<CNEVMData> vecPayload{nevmDataPayload};
-    if(!ProcessNEVMDataHelper(blockman, vecPayload, nMedianTime, nTimeNow, mapPoDA)) {
-        return false;
-    }
-    return true;
+    return ProcessNEVMDataHelper(blockman, vecPayload, nMedianTime, nTimeNow, mapPoDA);
 }
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.
  *  When FAILED is returned, view is left in an indeterminate state. */
@@ -3055,8 +3052,14 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
     }
     bool PODAContext = pindex->nHeight >= params.GetConsensus().nPODAStartBlock;
-    if(PODAContext && !ProcessNEVMData(m_chainman.m_blockman, block, pindex->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(m_chainman.m_options.adjusted_time_callback()), mapPoDA)) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "poda-validation-failed");
+    if(PODAContext) {
+        const auto poda_result = ProcessNEVMData(m_chainman.m_blockman, block, pindex->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(m_chainman.m_options.adjusted_time_callback()), mapPoDA);
+        if(poda_result == ProcessNEVMDataResult::CONSENSUS_INVALID) {
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "poda-validation-failed");
+        }
+        if(poda_result == ProcessNEVMDataResult::AUX_DATA_INVALID) {
+            return state.Error("poda-aux-data-invalid");
+        }
     }
 
     bool bRegTestContext = !fRegTest || (fRegTest && fNEVMConnection);
@@ -5237,11 +5240,18 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     // SYSCOIN ProcessNEVMData/FlushDataToCache so we have the data from processing out-of-order blocks and it reads from disk (recreating PoDA data in block) prior to validation in ConnectTip()
     bool PODAContext = pindex->nHeight >= params.GetConsensus().nPODAStartBlock;
     PoDAMAPMemory mapPoDA;
-    if(PODAContext && !ProcessNEVMData(m_blockman, block, pindex->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(this->m_options.adjusted_time_callback()), mapPoDA)) {
-        state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "poda-validation-failed");
-        pindex->nStatus |= BLOCK_FAILED_VALID;
-        m_blockman.m_dirty_blockindex.insert(pindex);
-        return error("%s: %s", __func__, state.ToString());
+    if(PODAContext) {
+        const auto poda_result = ProcessNEVMData(m_blockman, block, pindex->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(this->m_options.adjusted_time_callback()), mapPoDA);
+        if(poda_result == ProcessNEVMDataResult::CONSENSUS_INVALID) {
+            state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "poda-validation-failed");
+            pindex->nStatus |= BLOCK_FAILED_VALID;
+            m_blockman.m_dirty_blockindex.insert(pindex);
+            return error("%s: %s", __func__, state.ToString());
+        }
+        if(poda_result == ProcessNEVMDataResult::AUX_DATA_INVALID) {
+            state.Error("poda-aux-data-invalid");
+            return error("%s: %s", __func__, state.ToString());
+        }
     }
     if(pnevmdatadb)
         pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Block);
@@ -5585,7 +5595,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
         return error("%s: ProcessSpecialTxsInBlock for block %s failed with %s", __func__,
             pindex->GetBlockHash().ToString(), state.ToString());
     }
-    if(!ProcessNEVMData(m_chainman.m_blockman, block, pindex->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(m_chainman.m_options.adjusted_time_callback()), mapPoDA)) {
+    if(ProcessNEVMData(m_chainman.m_blockman, block, pindex->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(m_chainman.m_options.adjusted_time_callback()), mapPoDA) != ProcessNEVMDataResult::VALID) {
         return error("ReplayBlock(): poda-validation-failed");
     }
     for (const CTransactionRef& tx : block.vtx) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3052,7 +3052,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "poda-validation-failed");
         }
         if(poda_result == ProcessNEVMDataResult::AUX_DATA_INVALID) {
-            return state.Error("poda-aux-data-invalid");
+            return state.Invalid(BlockValidationResult::BLOCK_MUTATED, "poda-aux-data-invalid");
         }
     }
 
@@ -5243,7 +5243,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
             return error("%s: %s", __func__, state.ToString());
         }
         if(poda_result == ProcessNEVMDataResult::AUX_DATA_INVALID) {
-            state.Error("poda-aux-data-invalid");
+            state.Invalid(BlockValidationResult::BLOCK_MUTATED, "poda-aux-data-invalid");
             return error("%s: %s", __func__, state.ToString());
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2454,7 +2454,7 @@ bool ProcessNEVMDataHelper(const BlockManager& blockman, const std::vector<CNEVM
             LogPrint(BCLog::SYS, "ProcessNEVMDataHelper: Enforcing no data but NEVM Data is not empty nMedianTime %ld nTimeNow %ld NEVM_DATA_ENFORCE_TIME_NOT_HAVE_DATA %d\n", nMedianTime, nTimeNow, NEVM_DATA_ENFORCE_TIME_NOT_HAVE_DATA);
             return false;
         }
-        if(nevmDataPayload.vchNEVMData && !nevmDataPayload.vchNEVMData->empty()){
+        if(nevmDataPayload.vchNEVMData && !nevmDataPayload.vchNEVMData->empty() && !pnevmdatadb->BlobExists(nevmDataPayload.vchVersionHash)){
             vChecks.emplace_back(CBlobCheck(&nevmDataPayload));
         }
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -1354,8 +1354,13 @@ bool DisconnectNEVMCommitment(ChainstateManager& chainman, BlockValidationState&
 bool GetNEVMData(BlockValidationState& state, const CBlock& block, CNEVMHeader &evmBlock, std::vector<unsigned char>* coinbase_payload = nullptr);
 bool FillNEVMData(CBlock &block);
 bool EraseMempoolNEVMData(const std::vector<uint8_t>& vchVersionHash, const uint256& txid);
-bool ProcessNEVMData(const node::BlockManager& blockman, const CBlock &block, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA);
-bool ProcessNEVMData(const node::BlockManager& blockman, const CTransaction &tx, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA);
+enum class ProcessNEVMDataResult {
+    VALID,
+    CONSENSUS_INVALID,
+    AUX_DATA_INVALID,
+};
+ProcessNEVMDataResult ProcessNEVMData(const node::BlockManager& blockman, const CBlock &block, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA);
+ProcessNEVMDataResult ProcessNEVMData(const node::BlockManager& blockman, const CTransaction &tx, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA);
 /**
  * Return true if hash can be found in chainActive at nBlockHeight height.
  * Fills hashRet with found hash, if no nBlockHeight is specified - ::ChainActive().Height() is used.

--- a/src/validation.h
+++ b/src/validation.h
@@ -1353,7 +1353,6 @@ int RPCSerializationFlags();
 bool DisconnectNEVMCommitment(ChainstateManager& chainman, BlockValidationState& state, std::vector<uint256> &vecNEVMBlocks, const CBlock& block, const uint32_t& nHeight, const uint256& nBlockHash, const CDeterministicMNListNEVMAddressDiff &diff) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool GetNEVMData(BlockValidationState& state, const CBlock& block, CNEVMHeader &evmBlock, std::vector<unsigned char>* coinbase_payload = nullptr);
 bool FillNEVMData(CBlock &block);
-bool EraseNEVMData(const NEVMDataVec &NEVMDataVecOut);
 bool EraseMempoolNEVMData(const std::vector<uint8_t>& vchVersionHash, const uint256& txid);
 bool ProcessNEVMData(const node::BlockManager& blockman, const CBlock &block, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA);
 bool ProcessNEVMData(const node::BlockManager& blockman, const CTransaction &tx, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA);

--- a/src/validation.h
+++ b/src/validation.h
@@ -1354,6 +1354,7 @@ bool DisconnectNEVMCommitment(ChainstateManager& chainman, BlockValidationState&
 bool GetNEVMData(BlockValidationState& state, const CBlock& block, CNEVMHeader &evmBlock, std::vector<unsigned char>* coinbase_payload = nullptr);
 bool FillNEVMData(CBlock &block);
 bool EraseNEVMData(const NEVMDataVec &NEVMDataVecOut);
+bool EraseMempoolNEVMData(const std::vector<uint8_t>& vchVersionHash, const uint256& txid);
 bool ProcessNEVMData(const node::BlockManager& blockman, const CBlock &block, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA);
 bool ProcessNEVMData(const node::BlockManager& blockman, const CTransaction &tx, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA);
 /**

--- a/test/functional/feature_nevm_data.py
+++ b/test/functional/feature_nevm_data.py
@@ -247,40 +247,6 @@ class NEVMDataTest(DashTestFramework):
         assert_equal(self.nodes[0].getnevmblobdata(txid, True)['data'], txidData)
         assert_equal(self.nodes[1].getnevmblobdata(vh, True)['data'], vhData)
         assert_equal(self.nodes[1].getnevmblobdata(txid, True)['data'], txidData)
-        print('Check duplicate PoDA metadata refresh rules...')
-        original_blob = self.nodes[0].getnevmblobdata(vh, True)
-        assert_equal(original_blob['data'], vhData)
-        original_txid = original_blob['txid']
-        original_mtp = original_blob['mtp']
-        original_size = original_blob['datasize']
-
-        short_data = secrets.token_hex(10)
-        short_txid = self.nodes[0].syscoincreaterawnevmblob(vh, short_data)['txid']
-        self.wait_until(lambda: short_txid in self.nodes[0].getrawmempool())
-        self.generate_helper(self.nodes[0], 1, sync_fun=self.no_op, nodes=self.nodes[0:4])
-        self.wait_until(lambda: self.sync_blocks_helper(self.nodes[0:4]))
-        short_blob = self.nodes[0].getnevmblobdata(vh, True)
-        assert_equal(short_blob['txid'], original_txid)
-        assert_equal(short_blob['mtp'], original_mtp)
-        assert_equal(short_blob['datasize'], original_size)
-        assert_equal(short_blob['data'], vhData)
-
-        same_size_data = secrets.token_hex(len(bytes.fromhex(vhData)))
-        while same_size_data == vhData:
-            same_size_data = secrets.token_hex(len(bytes.fromhex(vhData)))
-        same_size_txid = self.nodes[0].syscoincreaterawnevmblob(vh, same_size_data)['txid']
-        self.wait_until(lambda: same_size_txid in self.nodes[0].getrawmempool())
-        mempool_blob = self.nodes[0].getnevmblobdata(vh, True)
-        assert_equal(mempool_blob['txid'], original_txid)
-        assert_equal(mempool_blob['mtp'], original_mtp)
-        self.generate_helper(self.nodes[0], 1, sync_fun=self.no_op, nodes=self.nodes[0:4])
-        same_size_block = self.nodes[0].getbestblockhash()
-        self.wait_until(lambda: self.sync_blocks_helper(self.nodes[0:4]))
-        same_size_blob = self.nodes[0].getnevmblobdata(vh, True)
-        assert_equal(same_size_blob['txid'], same_size_txid)
-        assert_equal(same_size_blob['mtp'], self.nodes[0].getblockheader(same_size_block)['mediantime'])
-        assert_equal(same_size_blob['datasize'], original_size)
-        assert_equal(same_size_blob['data'], vhData)
         # test relay before block creation
         print('Create more blobs...')
         self.nodes[0].syscoincreatenevmblob(secrets.token_hex(55))

--- a/test/functional/feature_nevm_data.py
+++ b/test/functional/feature_nevm_data.py
@@ -247,6 +247,40 @@ class NEVMDataTest(DashTestFramework):
         assert_equal(self.nodes[0].getnevmblobdata(txid, True)['data'], txidData)
         assert_equal(self.nodes[1].getnevmblobdata(vh, True)['data'], vhData)
         assert_equal(self.nodes[1].getnevmblobdata(txid, True)['data'], txidData)
+        print('Check duplicate PoDA metadata refresh rules...')
+        original_blob = self.nodes[0].getnevmblobdata(vh, True)
+        assert_equal(original_blob['data'], vhData)
+        original_txid = original_blob['txid']
+        original_mtp = original_blob['mtp']
+        original_size = original_blob['datasize']
+
+        short_data = secrets.token_hex(10)
+        short_txid = self.nodes[0].syscoincreaterawnevmblob(vh, short_data)['txid']
+        self.wait_until(lambda: short_txid in self.nodes[0].getrawmempool())
+        self.generate_helper(self.nodes[0], 1, sync_fun=self.no_op, nodes=self.nodes[0:4])
+        self.wait_until(lambda: self.sync_blocks_helper(self.nodes[0:4]))
+        short_blob = self.nodes[0].getnevmblobdata(vh, True)
+        assert_equal(short_blob['txid'], original_txid)
+        assert_equal(short_blob['mtp'], original_mtp)
+        assert_equal(short_blob['datasize'], original_size)
+        assert_equal(short_blob['data'], vhData)
+
+        same_size_data = secrets.token_hex(len(bytes.fromhex(vhData)))
+        while same_size_data == vhData:
+            same_size_data = secrets.token_hex(len(bytes.fromhex(vhData)))
+        same_size_txid = self.nodes[0].syscoincreaterawnevmblob(vh, same_size_data)['txid']
+        self.wait_until(lambda: same_size_txid in self.nodes[0].getrawmempool())
+        mempool_blob = self.nodes[0].getnevmblobdata(vh, True)
+        assert_equal(mempool_blob['txid'], original_txid)
+        assert_equal(mempool_blob['mtp'], original_mtp)
+        self.generate_helper(self.nodes[0], 1, sync_fun=self.no_op, nodes=self.nodes[0:4])
+        same_size_block = self.nodes[0].getbestblockhash()
+        self.wait_until(lambda: self.sync_blocks_helper(self.nodes[0:4]))
+        same_size_blob = self.nodes[0].getnevmblobdata(vh, True)
+        assert_equal(same_size_blob['txid'], same_size_txid)
+        assert_equal(same_size_blob['mtp'], self.nodes[0].getblockheader(same_size_block)['mediantime'])
+        assert_equal(same_size_blob['datasize'], original_size)
+        assert_equal(same_size_blob['data'], vhData)
         # test relay before block creation
         print('Create more blobs...')
         self.nodes[0].syscoincreatenevmblob(secrets.token_hex(55))


### PR DESCRIPTION
## Summary
- Restore the known-blob guard before PoDA sidecar hash checks so mutated network-only blob bytes cannot mark a valid block hash failed.
- Keeps duplicate blob metadata from refreshing through the previous PR while avoiding consensus invalidation on uncommitted auxiliary data mismatches.

## Test plan
- ReadLints on `src/validation.cpp` and `src/services/nevmconsensus.cpp`
- Not run: full build or functional tests


Made with [Cursor](https://cursor.com)