### PR TITLE
validation: verify supplied PoDA sidecars

### DIFF
--- a/src/test/nevm_tests.cpp
+++ b/src/test/nevm_tests.cpp
@@ -262,7 +262,8 @@ BOOST_AUTO_TEST_CASE(nevm_blob_sidecar_failures_are_auxiliary)
 
     BOOST_CHECK_EQUAL(
         ProcessNEVMData(m_node.chainman->m_blockman, MakeNEVMDataTx(version_hash, bad_data), /*nMedianTime=*/100, /*nTimeNow=*/100, mapPoDA),
-        ProcessNEVMDataResult::VALID);
+        ProcessNEVMDataResult::AUX_DATA_INVALID);
+    BOOST_CHECK(mapPoDA.empty());
 
     std::vector<CTransactionRef> txs;
     txs.emplace_back(MakeTransactionRef(CMutableTransaction{}));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2448,7 +2448,7 @@ ProcessNEVMDataResult ProcessNEVMDataHelper(const BlockManager& blockman, const 
             LogPrint(BCLog::SYS, "ProcessNEVMDataHelper: Enforcing no data but NEVM Data is not empty nMedianTime %ld nTimeNow %ld NEVM_DATA_ENFORCE_TIME_NOT_HAVE_DATA %d\n", nMedianTime, nTimeNow, NEVM_DATA_ENFORCE_TIME_NOT_HAVE_DATA);
             return ProcessNEVMDataResult::AUX_DATA_INVALID;
         }
-        if(nevmDataPayload.vchNEVMData && !nevmDataPayload.vchNEVMData->empty() && !pnevmdatadb->BlobExists(nevmDataPayload.vchVersionHash)){
+        if(nevmDataPayload.vchNEVMData && !nevmDataPayload.vchNEVMData->empty()){
             vChecks.emplace_back(CBlobCheck(&nevmDataPayload));
         }
     }


### PR DESCRIPTION
## Summary
- Ensures supplied PoDA sidecar bytes are validated consistently before they can populate PoDA state.
- Updates the NEVM PoDA unit coverage for the known-blob sidecar path.

## Test plan
- `src/test/test_syscoin --run_test=nevm_poda_validation_tests`
- `test/functional/feature_nevm_data.py`


Made with [Cursor](https://cursor.com)